### PR TITLE
Quote positional parameters in vagrant wrapper script.

### DIFF
--- a/cookbooks/vagrant/templates/default/vagrant.erb
+++ b/cookbooks/vagrant/templates/default/vagrant.erb
@@ -31,4 +31,4 @@ export CFLAGS="${CFLAGS}-I${EMBEDDED_DIR}/include -L${EMBEDDED_DIR}/lib}"
 export LDFLAGS="${LDFLAGS}-I${EMBEDDED_DIR}/include -L${EMBEDDED_DIR}/lib}"
 
 # Call the actual Vagrant bin with our arguments
-${EMBEDDED_DIR}/bin/ruby ${GEM_PATH}/bin/vagrant $@
+${EMBEDDED_DIR}/bin/ruby ${GEM_PATH}/bin/vagrant "$@"


### PR DESCRIPTION
The un-quoted `$@` causes ARGV to split token inside a quoted string. For example: `vagrant ssh -c 'sudo whoami'` becomes `["ssh", "-c", "sudo", "whoami"]`. With a quoted `$@` we get `["ssh", "-c", "sudo whoami"]`.

References https://github.com/mitchellh/vagrant/issues/775
