### PR TITLE
Fix errors when `uname -o` is not a valid command

### DIFF
--- a/cookbooks/vagrant/templates/default/vagrant.erb
+++ b/cookbooks/vagrant/templates/default/vagrant.erb
@@ -38,7 +38,9 @@ VAGRANT_EXECUTABLE=${EMBEDDED_DIR}/bin/vagrant
 
 # If we're in Cygwin, we want to convert the path to a Windows path, rather
 # than a Cygwin path, which Ruby does not work with.
-if [ `uname -o` = "Cygwin" ]; then
+# uname -o is not POSIX compliant, so be extra careful
+OS=$(uname -o 2> /dev/null)
+if [ "${OS}" = "Cygwin" ]; then
 	VAGRANT_EXECUTABLE=`cygpath -w "${VAGRANT_EXECUTABLE}"`
 fi
 <% else -%>


### PR DESCRIPTION
Fix the following error on *nix distros that do not support the -o option for uname:
$ vagrant up
uname: invalid option -- o
Try `uname --help' for more information.
/c/vagrant/vagrant/bin/vagrant: line 34: [: =: unary operator expected
