### PR TITLE
Add description, homepage, and license to deb package

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -1,4 +1,12 @@
 ---
 linux_prefix: "/opt/vagrant"
 deb_maintainer: "HashiCorp <hello@hashicorp.com>"
+deb_description: "Vagrant is a tool for building and distributing development environments.
+
+Vagrant provides the framework and configuration format to create and manage
+complete portable development environments. These development environments can
+live on your computer or in the cloud, and are portable between Windows,
+Mac OS X, and Linux"
+deb_homepage: "http://www.vagrantup.com/"
+deb_license: "MIT"
 fpm_version: "0.4.29"


### PR DESCRIPTION
As I was installing vagrant 1.1 today I noticed that the package installer said "no description given". Upon further inspection I noticed a few more fields were blank.

% dpkg --info vagrant_x86_64.deb 
 new debian package, version 2.0.

 size 19853862 bytes: control archive=368 bytes.
        0 bytes,     0 lines      conffiles
        279 bytes,    11 lines      control
 Package: vagrant
 Version: 1.1.0
 **License: unknown**
 Vendor: @vmware-ubuntu-10-04-amd64
 Architecture: amd64
 Maintainer: HashiCorp hello@hashicorp.com
 Installed-Size: 63022
 Section: default
 Priority: extra
**Homepage: http://example.com/no-uri-given**
**Description: no description given**

I've added values to the hiera file for these fields and utilized them in the https://github.com/hashicorp/puppet-modules/pull/3 repo. The description is from the readme in the vagrant repo. Hopefully everything is in the proper place. I tried to copy the similar code. Let me know if it needs changing in any way.
