### PR TITLE
"Error: You must set a homebrew user" when running ./run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ there may be more steps involved but the basic idea is the same:
 
 #### Build
 
+Edit the `hiera/Darwin.yaml` file and change the parameters to your signing key & user:
+
+    darwin_pkg_sign: "Developer ID Installer: John Doe"
+    homebrew_user: jdoe
+
     ./run.sh ${REVISION} ${OUTPUT_DIRECTORY}
 
 The resulting `dmg` will appear in the output directory.


### PR DESCRIPTION
Ran into an error first time running the packager:

```
Error: You must set a homebrew user. at /Users/jcuzella/src/pub/vagrant-installers/modules/homebrew/manifests/params.pp:10 on node vagrant.local
```

This was probably just left out of the documentation, so I've added a note in the README
- Add README note about hiera parameter data necessary for build on Darwin
