### PR TITLE
Windows: make ruby aware of our CA bundle

### DIFF
--- a/modules/vagrant_installer/templates/windows_vagrant.bat.erb
+++ b/modules/vagrant_installer/templates/windows_vagrant.bat.erb
@@ -14,6 +14,9 @@ SET "GEM_HOME=%EMBEDDED_DIR%\gems"
 SET "GEM_PATH=%GEM_HOME%"
 SET "GEMRC=%EMBEDDED_DIR%\etc\gemrc"
 
+REM Make ruby aware of our CA bundle
+SET "SSL_CERT_FILE=%EMBEDDED_DIR%\cacert.pem"
+
 REM Export an enviromental variable to say we're in a Vagrant
 REM installer created environment.
 SET "VAGRANT_INSTALLER_ENV=1"


### PR DESCRIPTION
On Windows, the _net/http_ library of the Vagrant's embedded ruby does **not** check the validity of an SSL certificate during a TLS handshake. This will cause issues to providers that use https and SSL certificates for their API calls.

For fixing this issue, we can make ruby aware of our certificate authority bundle by setting `SSL_CERT_FILE`.

Here is a more detailed explanation of the problem:
https://gist.github.com/fnichol/867550
