### PR TITLE
Localize environment changes in vagrant.bat with SETLOCAL

### DIFF
--- a/modules/vagrant_installer/templates/windows_vagrant.bat.erb
+++ b/modules/vagrant_installer/templates/windows_vagrant.bat.erb
@@ -1,13 +1,9 @@
 @ECHO OFF
+REM Localize environment changes
+SETLOCAL
+
 REM Some variables
 SET "EMBEDDED_DIR=%~dp0\..\embedded"
-
-REM Save some variables we're going to change so we can restore them later
-SET "VAGRANT_GEM_HOME_SAVED=%GEM_HOME%"
-SET "VAGRANT_GEM_PATH_SAVED=%GEM_PATH%"
-SET "VAGRANT_GEMRC_SAVED=%GEMRC%"
-SET "VAGRANT_PATH_SAVED=%PATH%"
-SET "VAGRANT_RUBYOPT_SAVED=%RUBYOPT%"
 
 REM Set environmental variables
 SET "GEM_HOME=%EMBEDDED_DIR%\gems"
@@ -29,15 +25,5 @@ SET RUBYOPT=
 REM Run Vagrant...
 "%EMBEDDED_DIR%\..\embedded\bin\ruby.exe" "%EMBEDDED_DIR%/../embedded/gems/bin/%~n0" %*
 
-REM Store the exit status so we can re-use it later
-SET "VAGRANT_EXIT_STATUS=%ERRORLEVEL%"
-
-REM Restore some environmental variables we changed
-SET "GEM_HOME=%VAGRANT_GEM_HOME_SAVED%"
-SET "GEM_PATH=%VAGRANT_GEM_PATH_SAVED%"
-SET "GEMRC=%VAGRANT_GEMRC_SAVED%"
-SET "PATH=%VAGRANT_PATH_SAVED%"
-SET "RUBYOPT=%VAGRANT_RUBYOPT_SAVED%"
-
 REM Exit with the proper exit status from Vagrant
-exit /b %VAGRANT_EXIT_STATUS%
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
I use vagrant regularly in Windows.  In the past I've encountered some issues caused by environment variables not being properly reset in vagrant.bat.  These have since been fixed. 

Using SETLOCAL should prevent these problems in the future as it keeps all environment changes local to the batch file run.  When the batch file exits, the environment goes back to what it was before.
