### PR TITLE
Make vagrant.erb work with relative symbolic links

### DIFF
--- a/modules/vagrant_installer/templates/vagrant.erb
+++ b/modules/vagrant_installer/templates/vagrant.erb
@@ -7,9 +7,10 @@
 # Get the directory where this script is. This will also resolve
 # any symlinks in the directory/script, so it will be the fully
 # resolved path.
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+CURDIR="$(pwd)"
+while [ -h "$SOURCE" ] ; do cd "$(dirname "$SOURCE")"; SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+cd "$CURDIR"
 
 # Useful variables
 EMBEDDED_DIR="${DIR}/../embedded"


### PR DESCRIPTION
First reported at https://github.com/mitchellh/vagrant/issues/2684.
