### PR TITLE
substrate: Also unset RUBYLIB.

### DIFF
--- a/substrate/modules/vagrant_installer/templates/vagrant.erb
+++ b/substrate/modules/vagrant_installer/templates/vagrant.erb
@@ -56,8 +56,10 @@ export VAGRANT_DETECTED_OS="${OS}"
 # Prepend our embedded dir to the PATH so that we call that preferably
 export PATH="${EMBEDDED_DIR}/bin:${PATH}"
 
-# Unset any RUBYOPT, we don't want this bleeding into our runtime.
+# Unset any RUBYOPT and RUBYLIB, we don't want these bleeding into our
+# runtime.
 unset RUBYOPT
+unset RUBYLIB
 
 # Set the path to the Ruby executable
 RUBY_EXECUTABLE="${EMBEDDED_DIR}/bin/ruby"

--- a/substrate/modules/vagrant_installer/templates/windows_vagrant.bat.erb
+++ b/substrate/modules/vagrant_installer/templates/windows_vagrant.bat.erb
@@ -22,8 +22,9 @@ SET "VAGRANT_INSTALLER_VERSION=<%= @installer_version %>"
 REM Prepend embedded bin to PATH so we prefer those binaries
 SET "PATH=%EMBEDDED_DIR%\bin;%EMBEDDED_DIR%\gnuwin32\bin;%PATH%"
 
-REM Remove RUBYOPT, which causes serious problems.
+REM Remove RUBYOPT and RUBYLIB, which cause serious problems.
 SET RUBYOPT=
+SET RUBYLIB=
 
 REM Run Vagrant...
 "%EMBEDDED_DIR%\..\embedded\bin\ruby.exe" "%EMBEDDED_DIR%/../embedded/gems/bin/%~n0" %*

--- a/substrate/modules/vagrant_substrate/templates/vagrant.bat.erb
+++ b/substrate/modules/vagrant_substrate/templates/vagrant.bat.erb
@@ -22,8 +22,9 @@ SET "VAGRANT_INSTALLER_VERSION=<%= @installer_version %>"
 REM Prepend embedded bin to PATH so we prefer those binaries
 SET "PATH=%EMBEDDED_DIR%\bin;%EMBEDDED_DIR%\gnuwin32\bin;%PATH%"
 
-REM Remove RUBYOPT, which causes serious problems.
+REM Remove RUBYOPT and RUBYLIB, which cause serious problems.
 SET RUBYOPT=
+SET RUBYLIB=
 
 REM Run Vagrant...
 "%EMBEDDED_DIR%\..\embedded\bin\ruby.exe" "%EMBEDDED_DIR%/../embedded/gems/bin/%~n0" %*

--- a/substrate/modules/vagrant_substrate/templates/vagrant.erb
+++ b/substrate/modules/vagrant_substrate/templates/vagrant.erb
@@ -56,8 +56,10 @@ export VAGRANT_DETECTED_OS="${OS}"
 # Prepend our embedded dir to the PATH so that we call that preferably
 export PATH="${EMBEDDED_DIR}/bin:${PATH}"
 
-# Unset any RUBYOPT, we don't want this bleeding into our runtime.
+# Unset any RUBYOPT and RUBYLIB, we don't want these bleeding into our
+# runtime.
 unset RUBYOPT
+unset RUBYLIB
 
 # Set the path to the Ruby executable
 RUBY_EXECUTABLE="${EMBEDDED_DIR}/bin/ruby"


### PR DESCRIPTION
Ref https://github.com/mitchellh/vagrant/issues/3193

Similar to `$RUBYOPT` being in the environment, `$RUBYLIB` can also cause issues. An example scenario where this is a problem for packaged vagrant:
1. I have vagrant installed on OS X via the installer at `/Applications/Vagrant` with its own embedded ruby
2. I have my own version of ruby (such as 2.1.1) installed elsewhere and use that for my work
3. I have a project which has a `Gemfile` that does not contain vagrant. I want to use the version I installed via the installer.
4. In the `Gemfile`, I use a gem, say, test-kitchen, that in turn wants to run vagrant
5. Using my ruby, I run `bundle exec kitchen test`
6. `bundle exec` exports `RUBYOPT=-rbundler/setup` and `RUBYLIB=/opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.0.rc/lib`, the latter being valid only for my ruby
7. Eventually test-kitchen runs `vagrant` and by virtue of `$PATH` it really runs `/usr/bin/vagrant`
8. Without this PR, `/usr/bin/vagrant` unsets only `RUBYOPT` which disables bundler autoloading but it does not unset `RUBYLIB`, which is still meant only for my ruby
9. `/usr/bin/vagrant` runs the embedded vagrant with the embedded ruby, still with `RUBYLIB` set
10. The embedded vagrant does `require "bundler"` or similar but finds my version of bundler instead of the embedded version at `/Applications/Vagrant/embedded/gems/gems/bundler-1.5.3`
11. As things are now, my version of bundler is not compatible with the embedded version so things blow up

With this PR, `RUBYLIB` is also unset letting the embedded vagrant's `require "bundler"` find the also-embedded version.

Some more snippets that show the leakage in action and that unsetting `RUBYLIB` fixes it:

```
$ echo > Gemfile
$ bundle install
The Gemfile specifies no dependencies
Resolving dependencies...
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.

# `bundle exec` exports these, meant only for my ruby
$ bundle exec bash -c env | egrep ^RUBY
RUBYOPT=-rbundler/setup
RUBYLIB=/opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.0.rc/lib

# RUBYLIB affects the embedded ruby as expected
$ bundle exec /Applications/Vagrant/embedded/bin/ruby -e 'puts $:.first'
/opt/boxen/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.0.rc/lib

# since I don't have vagrant in my bundle, it finds the installed packaged version's
# wrapper via $PATH
$ bundle exec bash -c 'which vagrant'
/usr/bin/vagrant

# trying to run via the wrapper breaks due to RUBYLIB being set with a load path
# meant for my ruby, containing my version of bundler
$ bundle exec vagrant
/Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/bundler.rb:31:in `initialize': undefined method `new' for Bundler::UI:Module (NoMethodError)
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/bundler.rb:17:in `new'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.5.0/lib/vagrant/bundler.rb:17:in `instance'
    from /Applications/Vagrant/bin/../embedded/gems/gems/vagrant-1.5.0/lib/vagrant/pre-rubygems.rb:22:in `<main>'

# however, running it again with RUBYLIB unset lets the embedded vagrant setup
# find its also embedded version of bundler
$ bundle exec bash -c 'unset RUBYLIB; vagrant'      
Usage: vagrant [options] <command> [<args>]
...
```

Hopefully I've done a better job explaining here than in the initial issue. Thanks for vagrant and your help.
