### PR TITLE
substrate: exec vagrant to eliminate bash launch wrapper

### DIFF
--- a/substrate/modules/vagrant_substrate/templates/vagrant.erb
+++ b/substrate/modules/vagrant_substrate/templates/vagrant.erb
@@ -113,4 +113,4 @@ esac
 export VAGRANT_EXECUTABLE
 
 # Call the actual Vagrant bin with our arguments
-"${RUBY_EXECUTABLE}" "${VAGRANT_LAUNCHER}" "$@"
+exec "${RUBY_EXECUTABLE}" "${VAGRANT_LAUNCHER}" "$@"


### PR DESCRIPTION
The Bash script that wraps Vagrant is badly behaved and eats certain signals.
Launch Vagrant with `exec` to replace the Bash wrapper and allow signals to be
handled directly by Vagrant.

Consider the following:

``` bash
$ vagrant rsync-auto &
$ kill -INT $!
```

`$!` returns the PID of the Bash wrapper script, not the Ruby process running
Vagrant. By default, Bash will ignore interrupts while running a command, so
Bash will swallow the signal generated by `kill -INT $!`, even though Vagrant
would exit had it received the signal.

You don't see this behavior on Ctrl-c, since Ctrl-c sends an interrupt to all
processes in the foreground process group—i.e., both Bash and Ruby.

(`kill -TERM $!` will successfully terminate the processes, but only after
printing an insuppressible "Terminated: 15" message.)
