### PR TITLE
fix problem with bsdtar by adding mingw to path

### DIFF
--- a/substrate/launcher/main.go
+++ b/substrate/launcher/main.go
@@ -57,9 +57,10 @@ func main() {
 	path = os.Getenv("PATH")
 	if runtime.GOOS == "windows" {
 		path = fmt.Sprintf(
-			"%s;%s;%s",
+			"%s;%s;%s;%s",
 			filepath.Join(embeddedDir, "bin"),
 			filepath.Join(embeddedDir, "gnuwin32", "bin"),
+			filepath.Join(embeddedDir, "mingw", "bin"),
 			path)
 	} else {
 		path = fmt.Sprintf("%s:%s",


### PR DESCRIPTION
I have found the place to add the PATH for the embeddedDir\mingw\bin\bsdtar.exe.
Golang makes it really easy to create native binaries.
I have built this modified launcher.exe in a windows environment with missing bsdtar.exe in the embeddedDir\gnuwin32\bin directory after an update of Vagrant 1.5.3 -> 1.6.3.

And indeed a call 

```
vagrant box add dummy https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
```

works fine with the mingw\bin\bsdtar.exe now found in PATH.

I don't know if it is intended to add the mingw directory tree to the MSI installer, but as it is there, vagrant could use this binaries.
But then the gnuwin32 directory could be removed and also adding it to the PATH.
And, of course, the package.ps1 could be simplified again and the PR #37 could be reverted.

Another idea: Perhaps rsync.exe could also be added this way to make it easier for windows users to use rsync synced folders as well.
