### PR TITLE
Fix for SSL_CERT_FILE in cygwin

### DIFF
--- a/substrate/modules/vagrant_installer/templates/vagrant.erb
+++ b/substrate/modules/vagrant_installer/templates/vagrant.erb
@@ -90,6 +90,7 @@ case $OS in
 		VAGRANT_INSTALLER_EMBEDDED_DIR=`cygpath -wla "${EMBEDDED_DIR}"`
 		GEM_HOME=`cygpath -wla "${GEM_HOME}"`
 		GEM_PATH=`cygpath -wla "${GEM_PATH}"`
+		SSL_CERT_FILE=`cygpath -wla "${SSL_CERT_FILE}"`
 		;;
 esac
 


### PR DESCRIPTION
The vagrant aws plugin fails in cygwin because the SSL_CERT_FILE path is a cygwin path. https://github.com/mitchellh/vagrant-aws/issues/184

I assume like other paths for ruby we'd want this to be changed back to a windows path.

I'd be happy to add some tests for this but I'm not sure what is expected for this project.
