### PR TITLE
Remove -delete_rpath modification on Ruby .bundle files

### DIFF
--- a/substrate/modules/ruby/manifests/source.pp
+++ b/substrate/modules/ruby/manifests/source.pp
@@ -119,13 +119,6 @@ class ruby::source(
       subscribe => Autotools["ruby"],
     }
 
-    exec { "remove-ruby-bundle-rpaths":
-      command     => "find ${prefix}/lib/ruby -type f -name '*.bundle' -exec install_name_tool -delete_rpath ${embedded_dir} {} \\;",
-      refreshonly => true,
-      require     => Autotools["ruby"],
-      subscribe   => Autotools["ruby"],
-    }
-
     exec { "modify-ruby-bundle-link-names":
       command     => "find ${prefix}/lib/ruby -type f -name '*.bundle' -exec install_name_tool -change ${original_lib_path} ${lib_path} {} \\;",
       refreshonly => true,


### PR DESCRIPTION
The -delete_rpath was resulting in an empty load command being
appended to the library which would cause loading errors on
other versions of macOS. This simply removes the modification
to resolve the issue.