### PR TITLE
Insert rpath when there is not one available to replace

### DIFF
--- a/substrate/modules/build_essential/manifests/init.pp
+++ b/substrate/modules/build_essential/manifests/init.pp
@@ -59,7 +59,7 @@ class build_essential {
 
     'Ubuntu': {
       package {
-        ["build-essential", "autoconf", "automake", "chrpath", "libtool"]:
+        ["build-essential", "autoconf", "automake", "chrpath", "libtool", "patchelf"]:
           ensure => installed,
       }
 

--- a/substrate/modules/build_essential/templates/centos_build_autotools.sh.erb
+++ b/substrate/modules/build_essential/templates/centos_build_autotools.sh.erb
@@ -44,3 +44,14 @@ pushd libtool*
 make
 make install
 popd
+
+# patchelf
+
+rm -rf patchelf*
+wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz
+tar xvzf patchelf-0.9.tar.gz
+pushd patchelf*
+./configure
+make
+make install
+popd

--- a/substrate/modules/vagrant_substrate/files/linux_rpath.sh
+++ b/substrate/modules/vagrant_substrate/files/linux_rpath.sh
@@ -24,15 +24,20 @@ for so_path in $(find "${embedded_dir}" -name "*.so"); do
     fi
 done
 
-for exe_path in $(find "${embedded_dir}" -type f); do
-    chrpath --list "${exe_path}"
+for exe_path in $(find "${embedded_dir}" -executable -type f); do
+    file "${exe_path}" | grep "ELF"
     if [ $? -eq 0 ]; then
-        set -e
-        exe_dir=$(dirname "${exe_path}")
-        rel_embedded=$(relpath "${exe_dir}" "${embedded_dir}")
-        rpath="\$ORIGIN/${rel_embedded}/lib:\$ORIGIN/${rel_embedded}/lib64"
-        chrpath --replace "${rpath}" "${exe_path}"
-        set +e
+        chrpath --list "${exe_path}"
+        if [ $? -eq 0 ]; then
+            set -e
+            exe_dir=$(dirname "${exe_path}")
+            rel_embedded=$(relpath "${exe_dir}" "${embedded_dir}")
+            rpath="\$ORIGIN/${rel_embedded}/lib:\$ORIGIN/${rel_embedded}/lib64"
+            chrpath --replace "${rpath}" "${exe_path}"
+            set +e
+        fi
+    else
+        patchelf --set-rpath "${rpath}" "${exe_path}"
     fi
 done
 


### PR DESCRIPTION
Fixes issue with generated openssl binary. While not a large concern as it is not used directly, this at least makes it functional and usable if ever needed.