### PR TITLE
Fix `apt-add-repository` not being found

### DIFF
--- a/packer/vagrant/scripts/ubuntu/ruby.sh
+++ b/packer/vagrant/scripts/ubuntu/ruby.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DEBIAN_FRONTEND=noninteractive apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -qy software-properties-common
 DEBIAN_FRONTEND=noninteractive apt-add-repository -y ppa:brightbox/ruby-ng
 DEBIAN_FRONTEND=noninteractive apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -qy ruby2.4 ruby2.4-dev build-essential zip unzip


### PR DESCRIPTION
I've started experimenting with the Vagrant packing process.

Noticed that if I use another image prefix, such as the `bento` boxes for example, `apt-add-repository` might not get found. 

To make it foul-proof, install explicitly the package that provides `apt-add-repository`.

@chrisroberts 