### PR TITLE
Update embedded Ruby to 2.5.3

### DIFF
--- a/packer/vagrant/scripts/ubuntu/ruby.sh
+++ b/packer/vagrant/scripts/ubuntu/ruby.sh
@@ -4,20 +4,20 @@ DEBIAN_FRONTEND=noninteractive apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -qy software-properties-common
 DEBIAN_FRONTEND=noninteractive apt-add-repository -y ppa:brightbox/ruby-ng
 DEBIAN_FRONTEND=noninteractive apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -qy ruby2.4 ruby2.4-dev build-essential zip unzip
+DEBIAN_FRONTEND=noninteractive apt-get install -qy ruby2.5 ruby2.5-dev build-essential zip unzip
 
-update-alternatives --remove ruby /usr/bin/ruby2.4
-update-alternatives --remove irb /usr/bin/irb2.4
-update-alternatives --remove gem /usr/bin/gem2.4
+update-alternatives --remove ruby /usr/bin/ruby2.5
+update-alternatives --remove irb /usr/bin/irb2.5
+update-alternatives --remove gem /usr/bin/gem2.5
 
 update-alternatives \
-     --install /usr/bin/ruby ruby /usr/bin/ruby2.4 50 \
-     --slave /usr/bin/irb irb /usr/bin/irb2.4 \
-     --slave /usr/bin/rake rake /usr/bin/rake2.4 \
-     --slave /usr/bin/gem gem /usr/bin/gem2.4 \
-     --slave /usr/bin/rdoc rdoc /usr/bin/rdoc2.4 \
-     --slave /usr/bin/testrb testrb /usr/bin/testrb2.4 \
-     --slave /usr/bin/erb erb /usr/bin/erb2.4 \
-     --slave /usr/bin/ri ri /usr/bin/ri2.4
+     --install /usr/bin/ruby ruby /usr/bin/ruby2.5 50 \
+     --slave /usr/bin/irb irb /usr/bin/irb2.5 \
+     --slave /usr/bin/rake rake /usr/bin/rake2.5 \
+     --slave /usr/bin/gem gem /usr/bin/gem2.5 \
+     --slave /usr/bin/rdoc rdoc /usr/bin/rdoc2.5 \
+     --slave /usr/bin/testrb testrb /usr/bin/testrb2.5 \
+     --slave /usr/bin/erb erb /usr/bin/erb2.5 \
+     --slave /usr/bin/ri ri /usr/bin/ri2.5
 
 update-alternatives --config ruby

--- a/packer/vagrant/scripts/ubuntu/ruby.sh
+++ b/packer/vagrant/scripts/ubuntu/ruby.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DEBIAN_FRONTEND=noninteractive apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -qy software-properties-common
 DEBIAN_FRONTEND=noninteractive apt-add-repository -y ppa:brightbox/ruby-ng
 DEBIAN_FRONTEND=noninteractive apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -qy ruby2.4 ruby2.4-dev build-essential zip unzip

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -16,7 +16,7 @@ libxslt_version="1.1.32"
 libyaml_version="0.1.7"
 openssl_version="1.1.0g"
 readline_version="7.0"
-ruby_version="2.4.4"
+ruby_version="2.5.3"
 xz_version="5.2.3"
 zlib_version="1.2.11"
 

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -78,7 +78,7 @@ pushd "${setupdir}"
 
 echo_stderr "  -> Installing any required packages..."
 if [[ "${linux_os}" = "ubuntu" ]]; then
-    apt-get install -qy build-essential autoconf automake chrpath libtool
+    DEBIAN_FRONTEND=noninteractive apt-get install -qy build-essential autoconf automake chrpath libtool
 fi
 
 if [[ "${linux_os}" = "centos" ]]; then

--- a/substrate/vagrant-scripts/ubuntu.sh
+++ b/substrate/vagrant-scripts/ubuntu.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 apt-get update -yq
-apt-get install -yq nc
+# NOTE: `nc` package may be available as `netcat`
+apt-get install -yq nc || apt-get install -yq netcat
 
 # if the proxy is around, use it
 nc -z -w3 192.168.1.1 8123 && export http_proxy="http://192.168.1.1:8123"


### PR DESCRIPTION
* Updates embedded Ruby to 2.5.3 - this is very important. Currently native extension-dependent plugins such as `vagrant-libvirt` don't work at all. https://github.com/hashicorp/vagrant/issues/7039#issuecomment-441291810 , https://gist.github.com/alexellis/046fa757113105ac1871644620756aed and many more
* Fix minor packages/differences and warnings

@chrisroberts

# TODO:

* Verify that Ruby 2.4.0 is completely removed. Looks good to me, though.

# What's been tested:

* Built a package and installed at Ubuntu 18.04 bionic
* Ran `vagrant plugin install vagrant-libvirt` - worked. Previously required manual `CFLAGS` to just make it install (but still not work) as mentioned in https://github.com/hashicorp/vagrant/issues/7039#issuecomment-441291810
* Actually managed to use the `libvirt` provisioner via `test-kitchen` vagrant driver with `provider: libvirt`
