### PR TITLE
Update exec call within appimage script

### DIFF
--- a/package/appimage/pkg2appimage
+++ b/package/appimage/pkg2appimage
@@ -246,7 +246,7 @@ if [ -z "${_union}" ] ; then
     get_apprun
 else
     cat > AppRun <<\EOF
-#!/bin/sh
+#!/usr/bin/env bash
 HERE="$(dirname "$(readlink -f "${0}")")"
 export UNION_PRELOAD="${HERE}"
 export LD_PRELOAD="${HERE}/libunionpreload.so"
@@ -259,7 +259,7 @@ export PERLLIB="${HERE}"/usr/share/perl5/:"${HERE}"/usr/lib/perl5/:"${PERLLIB}"
 export GSETTINGS_SCHEMA_DIR="${HERE}"/usr/share/glib-2.0/schemas/:"${GSETTINGS_SCHEMA_DIR}"
 export QT_PLUGIN_PATH="${HERE}"/usr/lib/qt4/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib32/qt4/plugins/:"${HERE}"/usr/lib64/qt4/plugins/:"${HERE}"/usr/lib/qt5/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib32/qt5/plugins/:"${HERE}"/usr/lib64/qt5/plugins/:"${QT_PLUGIN_PATH}"
 EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2- | sed -e 's|%.||g')
-exec ${EXEC} $@
+exec "${EXEC}" "$@"
 EOF
     chmod a+x AppRun
 fi


### PR DESCRIPTION
Prevent arguments from being parsed incorrectly when passing
through to exec.

Fixes hashicorp/vagrant#10696