### PR TITLE
Include libxcrypt-compat for compatibility with newer RHEL based hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ substrate/terraform/*.tfvars
 substrate/terraform/output
 pkg
 substrate-assets
+cacert.pem

--- a/package/vagrant-scripts/centos.sh
+++ b/package/vagrant-scripts/centos.sh
@@ -2,6 +2,10 @@
 
 yum install -y nc zip unzip chrpath
 
+sudo yum install -y centos-release-scl
+sudo yum install -y  devtoolset-8-toolchain
+source /opt/rh/devtoolset-8/enable
+
 # if the proxy is around, use it
 nc -z -w3 192.168.1.1 8123 && export http_proxy="http://192.168.1.1:8123"
 mkdir -p /vagrant/substrate-assets

--- a/substrate/launcher/main.go
+++ b/substrate/launcher/main.go
@@ -189,7 +189,7 @@ func main() {
 
 	newEnv := map[string]string{
 		// Setup the environment to prefer our embedded dir over
-		// anything the user might have setup on his/her system.
+		// anything the user might have setup on their system.
 		"CPPFLAGS":       cppflags,
 		"CFLAGS":         cflags,
 		"GEM_HOME":       filepath.Join(embeddedDir, "gems", vagrantVersion),

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -82,13 +82,12 @@ if [[ "${linux_os}" = "ubuntu" ]]; then
 fi
 
 if [[ "${linux_os}" = "centos" ]]; then
+    set +e
     # need newer gcc to build libxcrypt-compat package
     echo_stderr "      -> Installing custom gcc..."
     sudo yum install -y centos-release-scl
     sudo yum install -y devtoolset-8-toolchain
     source /opt/rh/devtoolset-8/enable
-
-    set +e
 
     yum -d 0 -e 0 -y install chrpath gcc make perl
     yum -d 0 -e 0 -y install perl-Data-Dumper


### PR DESCRIPTION
Prior to this pull request, hosts like Fedora 30 would fail because of the
changes in glibc removing libcrypt. This commit fixes that by installing
the libxcrypt-compat package so that Vagrant can still link against the
libcrypt.so library.

Related: https://fedoraproject.org/wiki/Changes/Replace_glibc_libcrypt_with_libxcrypt

Fixes hashicorp/vagrant#10830