### PR TITLE
Add package signing requirement to package scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ reference:
     PACKET_EXEC_OPERATING_SYSTEM: ubuntu_18_04
     PACKET_EXEC_PRE_BUILTINS: InstallVmware,InstallVagrant,InstallVagrantVmware
     PACKET_EXEC_SSH_KEY: /tmp/packet-ssh-key
+    PKT_VAGRANT_INSTALLERS_VAGRANT_PACKAGE_SIGNING_REQUIRED: 1
   copypasta:
     default_workflow: &DEFAULT_WORKFLOW
       context: vagrant

--- a/package/package.ps1
+++ b/package/package.ps1
@@ -30,6 +30,7 @@ param(
     [string]$SignKey="",
     [string]$SignKeyPassword="",
     [string]$SignPath="",
+    [string]$SignRequired="",
 
     [string]$BuildStyle="ephemeral",
     [string]$ScrubCache="no"
@@ -484,6 +485,10 @@ if ($SignKey) {
         exit 1
     }
 } else {
+    if ($SignRequired -eq "1") {
+        Write-Host "Error: Package signing is required but package is not signed"
+        exit 1
+    }
     Write-Host "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
     Write-Host "!      This package is unsigned        !"
     Write-Host "! Rebuild with signing key for release !"

--- a/package/support/package_darwin.sh
+++ b/package/support/package_darwin.sh
@@ -34,6 +34,8 @@ CODE_SIGN_CERT_PATH=${VAGRANT_CODE_SIGN_CERT_PATH:-none}
 CODE_SIGN_KEY_PATH=${VAGRANT_CODE_SIGN_KEY_PATH:-none}
 
 SIGN_KEYCHAIN=${VAGRANT_SIGN_KEYCHAIN:-/Library/Keychains/System.keychain}
+
+SIGN_REQUIRED="${VAGRANT_PACKAGE_SIGNING_REQUIRED}"
 #-------------------------------------------------------------------------
 # Resources
 #-------------------------------------------------------------------------
@@ -208,6 +210,11 @@ dmgbuild -s "${DIR}/darwin/dmgbuild.py" -D srcfolder="${STAGING_DIR}/dmg" -D bac
 
 if [[ "${SIGN_PKG}" -ne "1" ]]
 then
+    if [[ "${SIGN_REQUIRED}" -eq "1" ]]
+    then
+        echo "Error: Package signing is required but package is not signed"
+        exit 1
+    fi
     set +x
     echo
     echo "!!!!!!!!!!!! WARNING !!!!!!!!!!!!"

--- a/package/vagrant-scripts/win.ps1
+++ b/package/vagrant-scripts/win.ps1
@@ -50,12 +50,14 @@ if($SignKeyExists) {
         "SubstratePath"="${SubstratePath}";
         "VagrantRevision"="master";
         "SignKey"="${SignKeyPath}";
-        "SignKeyPassword"="${env:SignKeyPassword}"
+        "SignKeyPassword"="${env:SignKeyPassword}";
+        "SignRequired"="${env:VAGRANT_PACKAGE_SIGNING_REQUIRED}";
     }
 } else {
     $PackageArgs = @{
         "SubstratePath"="${SubstratePath}";
-        "VagrantRevision"="master"
+        "VagrantRevision"="master";
+        "SignRequired"="${env:VAGRANT_PACKAGE_SIGNING_REQUIRED}";
     }
 }
 
@@ -77,12 +79,14 @@ if($SignKeyExists) {
         "SubstratePath"="${SubstratePath}";
         "VagrantRevision"="master";
         "SignKey"="${SignKeyPath}";
-        "SignKeyPassword"="${env:SignKeyPassword}"
+        "SignKeyPassword"="${env:SignKeyPassword}";
+        "SignRequired"="${env:VAGRANT_PACKAGE_SIGNING_REQUIRED}";
     }
 } else {
     $PackageArgs = @{
         "SubstratePath"="${SubstratePath}";
-        "VagrantRevision"="master"
+        "VagrantRevision"="master";
+        "SignRequired"="${env:VAGRANT_PACKAGE_SIGNING_REQUIRED}";
     }
 }
 


### PR DESCRIPTION
Provide an environment variable to enable required package signing.
When enabled an error will be forced when a package which can be
signed is not.

see: #151