### PR TITLE
Fix setting of build related environment variables

### DIFF
--- a/substrate/launcher/Makefile
+++ b/substrate/launcher/Makefile
@@ -1,4 +1,0 @@
-build:
-	gox -output="../modules/vagrant_substrate/files/launcher_{{.OS}}_{{.Arch}}" -os="darwin freebsd linux netbsd openbsd windows"
-
-.PHONY: build


### PR DESCRIPTION
User defined environment variables related to compiling
were not being properly set due to bad scoping. This
fixes that so they are properly included within the
newly generated environment. Also included `CXXFLAGS`
and `CONFIGURE_ARGS`

Fixes hashicorp/vagrant#11333