### PR TITLE
[vagrant-launcher] Add go modules

### DIFF
--- a/substrate/launcher/go.mod
+++ b/substrate/launcher/go.mod
@@ -1,0 +1,5 @@
+module vagrant-launcher
+
+go 1.14
+
+require github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f

--- a/substrate/launcher/go.sum
+++ b/substrate/launcher/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f h1:2+myh5ml7lgEU/51gbeLHfKGNfgEQQIWrlbdaOsidbQ=
+github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=


### PR DESCRIPTION
We should pin the dependencies so we know which versions are used to
build the binary.

Signed-off-by: Morten Linderud <morten@linderud.pw>