### PR TITLE
Update SDK location for macOS builds

### DIFF
--- a/package/support/package_darwin.sh
+++ b/package/support/package_darwin.sh
@@ -7,14 +7,27 @@ if [ "$#" -ne "2" ]; then
   exit 1
 fi
 
-export MACOSX_DEPLOYMENT_TARGET="10.9"
-export SDKROOT="/Users/vagrant/SDKs/MacOSX10.9.sdk" #"$(xcrun --sdk macosx --show-sdk-path)"
+macos_deployment_target="10.9"
+
+sdk_root="/Library/Developer/CommandLineTools/SDKs"
+sdk_path="${sdk_root}/MacOSX.sdk"
+versioned_sdk_path="${sdk_root}/MacOSX${macos_deployment_target}.sdk"
+# Check that deployment target sdk exists
+if [ ! -d "${versioned_sdk_path}" ]; then
+    echo_stderr " !! Requested macOS SDK version is not available: ${macos_deployment_target}"
+    exit 1
+else
+    rm -f "${sdk_path}"
+    ln -s "${versioned_sdk_path}" "${sdk_path}"
+fi
+export MACOSX_DEPLOYMENT_TARGET="${macos_deployment_target}"
+export SDKROOT="${sdk_path}" #"$(xcrun --sdk macosx --show-sdk-path)"
 export ISYSROOT="-isysroot ${SDKROOT}"
 export SYSLIBROOT="-syslibroot ${SDKROOT}"
 export SYS_ROOT="${SDKROOT}"
-export CFLAGS="-mmacosx-version-min=10.9 ${ISYSROOT}"
+export CFLAGS="-mmacosx-version-min=${macos_deployment_target} ${ISYSROOT}"
 export CXXFLAGS="${CFLAGS}"
-export LDFLAGS="-mmacosx-version-min=10.9 ${SYSLIBROOT}"
+export LDFLAGS="-mmacosx-version-min=${macos_deployment_target} ${SYSLIBROOT}"
 
 # Get our directory
 SOURCE="${BASH_SOURCE[0]}"

--- a/package/vagrant-scripts/osx.sh
+++ b/package/vagrant-scripts/osx.sh
@@ -11,6 +11,12 @@ mv gon /System/Volumes/Data/usr/local/bin/gon
 
 su vagrant -l -c 'brew install bash'
 
+# Move the SDK into the developer section
+sdk="/Users/vagrant/SDKs/MacOSX10.9.sdk"
+if [ -d "${sdk}" ]; then
+    mv "${sdk}" /Library/Developer/CommandLineTools/SDKs/
+fi
+
 chmod 755 /vagrant/package/package.sh
 
 set -e

--- a/substrate/vagrant-scripts/osx.sh
+++ b/substrate/vagrant-scripts/osx.sh
@@ -18,6 +18,12 @@ mv cacert.pem /usr/local/etc/openssl/cacert.pem
 export SSL_CERT_FILE=/usr/local/etc/openssl/cacert.pem
 export PATH=$PATH:/usr/local/bin:/usr/local/go/bin
 
+# Move the SDK into the developer section
+sdk="/Users/vagrant/SDKs/MacOSX10.9.sdk"
+if [ -d "${sdk}" ]; then
+    mv "${sdk}" /Library/Developer/CommandLineTools/SDKs/
+fi
+
 set -e
 
 if [ "${VAGRANT_BUILD_DEBUG}" = "1" ]; then


### PR DESCRIPTION
Manually move the SDK location until an updated box is pushed. Link
the generic SDK path with deployment target so builds use the correct
path within generated config files.

Fixes #163