### PR TITLE
Remove vendored tooling within the appimage build

### DIFF
--- a/package/appimage.sh
+++ b/package/appimage.sh
@@ -47,7 +47,7 @@ Version: ${VAGRANT_VERSION}-1
 Section:
 Priority: optional
 Architecture: amd64
-Depends: ruby2.6, ruby2.6-dev, libssl1.0.0, libssl-dev, libgnutls28, libgnutls-dev, curl, libcurl4-gnutls-dev, bsdtar, libxml2, libxml2-dev, libxslt1-dev, libffi6, libffi-dev, libkeyutils1, openssh-client, libp11-kit-dev, zlib1g
+Depends: ruby2.6, ruby2.6-dev
 Maintainer: HashiCorp Vagrant Team <team-vagrant@hashicorp.com>
 Description: Vagrant is a tool for building and distributing development environments.
 EOF
@@ -64,7 +64,6 @@ apt-get update
 # Install required packages
 apt-get remove --purge -yq ruby2.4 ruby2.4-dev
 apt-get install -y build-essential ca-certificates ruby2.6 ruby2.6-dev
-update-ca-certificates
 
 export WORK_DIR
 export DEB_FILE

--- a/package/appimage/excludedeblist
+++ b/package/appimage/excludedeblist
@@ -15,9 +15,9 @@ dictionaries-common
 dpkg
 fontconfig
 fontconfig-config
-# gconf2 # elementary OS 0.4 Loki does NOT have libgconf-2-4
-# gconf2-common # elementary OS 0.4 Loki does NOT have libgconf-2-4
-# gconf-service # elementary OS 0.4 Loki does NOT have libgconf-2-4
+gconf2 # elementary OS 0.4 Loki does NOT have libgconf-2-4
+gconf2-common # elementary OS 0.4 Loki does NOT have libgconf-2-4
+gconf-service # elementary OS 0.4 Loki does NOT have libgconf-2-4
 gvfs-backends # e.g., for Bluefish
 gksu
 glib-networking
@@ -33,27 +33,27 @@ libc6
 libc6-dev
 libcairo2
 libcups2
-# libcurl3 # Does draw in a lot of libs including security relevant ones; e.g., in supertux2; but otherwise get ../lib/x86_64-linux-gnu/libssl.so.1.0.0: version `OPENSSL_1.0.2' not found (required by /usr/lib/x86_64-linux-gnu/libcurl.so.4)
-# libcurl3-gnutls # https://github.com/AppImage/AppImages/issues/120#issuecomment-261749714
-# libdbm2 # seems not to exist
+libcurl3 # Does draw in a lot of libs including security relevant ones; e.g., in supertux2; but otherwise get ../lib/x86_64-linux-gnu/libssl.so.1.0.0: version `OPENSSL_1.0.2' not found (required by /usr/lib/x86_64-linux-gnu/libcurl.so.4)
+libcurl3-gnutls # https://github.com/AppImage/AppImages/issues/120#issuecomment-261749714
+libdbm2 # seems not to exist
 libdbus-1-3
 libdrm2
 libegl1-mesa
 libfontconfig1
 libgbm1
 libgcc1
-# libgconf-2-4 # elementary OS 0.4 Loki does NOT have it
+libgconf-2-4 # elementary OS 0.4 Loki does NOT have it
 libgdk-pixbuf2.0-0
 libgl1
 libgl1-mesa
 libgl1-mesa-dri
 libgl1-mesa-glx
-# libglib2.0-0 # https://github.com/LibreCAD/LibreCAD/issues/858#issuecomment-345449318
+libglib2.0-0 # https://github.com/LibreCAD/LibreCAD/issues/858#issuecomment-345449318
 libglu1-mesa
-# libgnutls26 cannot be expected to be eveywhere, e.g., KDE neon
-# libgpg-error0 gives non-fatal errors on many systems and is low-level, can it be expected to be everywhere?
-# libgpg-error0
-# libgstreamer1.0-0
+libgnutls26 cannot be expected to be eveywhere, e.g., KDE neon
+libgpg-error0 gives non-fatal errors on many systems and is low-level, can it be expected to be everywhere?
+libgpg-error0
+libgstreamer1.0-0
 libgtk2.0-0
 libgtk-3-0
 libnss3
@@ -62,7 +62,7 @@ libpango-1.0-0
 libpangocairo-1.0-0 # Workaround for: openSUSE: undefined symbol: hb_buffer_set_cluster_level?; commenting this out leads to square boxes instead of fonts
 libpangoft2-1.0-0 # Workaround for: openSUSE: undefined symbol: hb_buffer_set_cluster_level?; commenting this out leads to square boxes instead of fonts
 libstdc++6
-#libtasn1-6
+libtasn1-6
 libwayland-egl1-mesa # e.g., OpenRA
 lsb-base
 libxcb1 # Workaround for: Fedora 25: undefined symbol: xcb_send_request_with_fds, https://github.com/AppImage/AppImages/issues/128

--- a/package/appimage/excludelist
+++ b/package/appimage/excludelist
@@ -67,8 +67,8 @@ libgio-2.0.so.0
 # Workaround for:
 # On Ubuntu, "symbol lookup error: /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/liboverlay-scrollbar.so: undefined symbol: g_settings_new"
 
-# libgdk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
-# libgtk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+libgdk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+libgtk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
 
 libasound.so.2
 # Workaround for:
@@ -108,27 +108,27 @@ libexpat.so.1
 libgcc_s.so.1
 libglib-2.0.so.0
 libgpg-error.so.0
-# libgssapi_krb5.so.2 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
-# libgssapi.so.3 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
-# libhcrypto.so.4 # Missing on openSUSE LEAP 42.0
-# libheimbase.so.1 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
-# libheimntlm.so.0 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
-# libhx509.so.5 # Missing on openSUSE LEAP 42.0
+libgssapi_krb5.so.2 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+libgssapi.so.3 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libhcrypto.so.4 # Missing on openSUSE LEAP 42.0
+libheimbase.so.1 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libheimntlm.so.0 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libhx509.so.5 # Missing on openSUSE LEAP 42.0
 libICE.so.6
-# libidn.so.11 # Does not come with Solus by default
-# libk5crypto.so.3 # Runnning AppImage built on Debian 9 or Ubuntu 16.04 on an Archlinux fails otherwise; https://github.com/AppImage/AppImages/issues/301
-# libkeyutils.so.1
-# libkrb5.so.26 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there. Missing on openSUSE LEAP 42.0
-# libkrb5.so.3 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
-# libkrb5support.so.0 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+libidn.so.11 # Does not come with Solus by default
+libk5crypto.so.3 # Runnning AppImage built on Debian 9 or Ubuntu 16.04 on an Archlinux fails otherwise; https://github.com/AppImage/AppImages/issues/301
+libkeyutils.so.1
+libkrb5.so.26 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there. Missing on openSUSE LEAP 42.0
+libkrb5.so.3 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+libkrb5support.so.0 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
 libp11-kit.so.0
-# libpcre.so.3 # Missing on Fedora 24, SLED 12 SP1, and openSUSE Leap 42.2
-# libroken.so.18 # Mission on openSUSE LEAP 42.0
-# libsasl2.so.2 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libpcre.so.3 # Missing on Fedora 24, SLED 12 SP1, and openSUSE Leap 42.2
+libroken.so.18 # Mission on openSUSE LEAP 42.0
+libsasl2.so.2 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
 libSM.so.6
 libusb-1.0.so.0
 libuuid.so.1
-# libwind.so.0 # Missing on openSUSE LEAP 42.0
+libwind.so.0 # Missing on openSUSE LEAP 42.0
 libz.so.1
 
 # Potentially dangerous libraries

--- a/package/appimage/vagrant.yml
+++ b/package/appimage/vagrant.yml
@@ -23,8 +23,6 @@ script:
   - echo "Terminal=true" >> vagrant.desktop
   - touch app.png
   - rm -f lib/x86_64-linux-gnu/libtinfo.so*
-  - mkdir -p etc/ssl
-  - cp /etc/ssl/certs/ca-certificates.crt etc/ssl/ca-certificates.crt
   - mkdir rgloader
   - cp "${WORK_DIR}/rgloader/"* rgloader/
   - mkdir -p usr/gembundle
@@ -33,3 +31,8 @@ script:
   - GEM_PATH=usr/gembundle GEM_HOME=usr/gembundle usr/bin/gem2.6 install pkg-config --no-document
   - mv "${WORK_DIR}/vagrant_wrapper.sh" usr/bin/vagrant
   - chmod a+x usr/bin/vagrant
+  - rm -rf usr/share/man
+  - rm -rf usr/share/info
+  - rm -rf usr/share/doc
+  - rm -rf usr/gembundle/cache
+  - mv usr/lib/x86_64-linux-gnu/pkgconfig usr/lib/x86_64-linux-gnu/pkgconfig-int

--- a/package/appimage/vagrant_wrapper.sh
+++ b/package/appimage/vagrant_wrapper.sh
@@ -4,6 +4,44 @@ SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
+# Determine where the CA certificate bundle is located. If
+# a custom value is provided, use that for the default. Otherwise
+# test known location for the file. If none is found, alert
+# the user and carry on.
+if [ -n "${SSL_CERT_FILE}" ]; then
+    if [ -f "${SSL_CERT_FILE}" ]; then
+        default_ssl_cert_file="${SSL_CERT_FILE}"
+    else
+        unset SSL_CERT_FILE
+    fi
+fi
+
+if [ -n "${CURL_CA_BUNDLE}" ]; then
+    if [ -f "${CURL_CA_BUNDLE}" ]; then
+        if [ -z "${default_ssl_cert_file}" ]; then
+            default_ssl_cert_file="${CURL_CA_BUNDLE}"
+        fi
+    else
+        unset CURL_CA_BUNDLE
+    fi
+fi
+
+if [ -z "${default_ssl_cert_file}" ]; then
+    if [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then
+        default_ssl_cert_file="/etc/ssl/certs/ca-certificates.crt"
+    elif [ -f "/etc/ssl/ca-certificates.crt" ]; then
+        default_ssl_cert_file="/etc/ssl/ca-certificates.crt"
+    elif [ -f "/etc/ca-certificates.crt" ]; then
+        default_ssl_cert_file="/etc/ca-certificates.crt"
+    else
+        echo "WARNING: Failed to locate ca-certificates.crt file!"
+        echo
+        echo   "Please locate the ca-certificates.crt file and set"
+        echo   "it to the SSL_CERT_FILE and CURL_CA_BUNDLE environment"
+        echo   "variables to ensure valid SSL behavior."
+    fi
+fi
+
 export RUBYLIB=""
 export RUBYOPT=""
 
@@ -13,16 +51,19 @@ export VAGRANT_ROOT_DIR="$( cd -P "$( dirname "$VAGRANT_USR_DIR" )" && pwd )"
 export GEM_HOME="${VAGRANT_USR_DIR}/gembundle"
 export GEM_PATH="${VAGRANT_USR_DIR}/gembundle"
 export RUBYLIB="$( "${VAGRANT_BIN_DIR}/ruby2.6" -e "puts $:.map{|x| ENV['VAGRANT_ROOT_DIR'] + x}.join(':')" )"
-if [ "${SSL_CERT_FILE}" = "" ]; then
-    export SSL_CERT_FILE="${VAGRANT_ROOT_DIR}/etc/ssl/ca-certificates.crt"
-fi
-if [ "${CURL_CA_BUNDLE}" = "" ]; then
-    export CURL_CA_BUNDLE="${VAGRANT_ROOT_DIR}/etc/ssl/ca-certificates.crt"
+
+# Set our SSL certificate locations unless they are already set
+if [ -z "${SSL_CERT_FILE}" ]; then
+    export SSL_CERT_FILE="${default_ssl_cert_file}"
 fi
 
-new_pkg_config_path="${VAGRANT_ROOT_DIR}/usr/lib/x86_64-linux-gnu/pkgconfig"
+if [ -z "${CURL_CA_BUNDLE}" ]; then
+    export CURL_CA_BUNDLE="${default_ssl_cert_file}"
+fi
 
-if [ "${PKG_CONFIG_PATH}" != "" ]; then
+new_pkg_config_path="${VAGRANT_ROOT_DIR}/usr/lib/x86_64-linux-gnu/pkgconfig-int"
+
+if [ -z "${PKG_CONFIG_PATH}" ]; then
     new_pkg_config_path="${new_pkg_config_path}:${PKG_CONFIG_PATH}"
 fi
 
@@ -34,7 +75,9 @@ export PKG_CONFIG_PATH="${new_pkg_config_path}"
 export VAGRANT_INSTALLER_ENV="1"
 export VAGRANT_APPIMAGE="1"
 export VAGRANT_INSTALLER_EMBEDDED_DIR="${VAGRANT_ROOT_DIR}"
-export NOKOGIRI_USE_SYSTEM_LIBRARIES="1"
+
+# Don't set this by default. Allow users to decide if system libraries should be used.
+# export NOKOGIRI_USE_SYSTEM_LIBRARIES="1"
 
 # Set these for easier debugging so they show up in the logs
 export VAGRANT_PKG_CONFIG_PATH="${PKG_CONFIG_PATH}"
@@ -48,7 +91,8 @@ fi
 
 new_ld_library_path="${LD_LIBRARY_PATH}"
 
-if [ -x "$(command -v ldconfig)" ]; then
+command -v ldconfig > /dev/null
+if [ $? -eq 0 ]; then
     extra_ld_path=$(ldconfig -N -X -v 2>&1 | grep "^/.*:$" | tr -d ":" | tr "\n" ":")
 else
     extra_ld_path="/lib:/lib64:/usr/lib:/usr/lib64"
@@ -64,5 +108,21 @@ export VAGRANT_APPIMAGE_LD_LIBRARY_PATH="${new_ld_library_path}"
 # Python variables will be set but we don't want them
 unset PYTHONHOME
 unset PYTHONPATH
+
+# Before we get started, check that curl and SSH are available
+if [ ! -x "$(command -v curl)" ]; then
+    echo "WARNING: Failed to locate `curl` executable"
+    echo "  Vagrant relies on `curl` for handling assets. Please"
+    echo "  ensure that `curl` has been installed to prevent errors"
+    echo "  when Vagrant is uploading or downloading assets."
+    echo
+fi
+
+if [ ! -x "$(command -v ssh)" ]; then
+    echo "WARNING: Failed to locate `ssh` executable"
+    echo "  Vagrant relies on the `ssh` command for connecting to"
+    echo "  guests. Please ensure that `ssh` has been installed to"
+    echo "  prevent error when Vagrant attempts to connect to guests."
+fi
 
 "${VAGRANT_BIN_DIR}/ruby2.6" -- "${VAGRANT_USR_DIR}/gembundle/bin/vagrant" "$@"

--- a/package/appimage/vagrant_wrapper.sh
+++ b/package/appimage/vagrant_wrapper.sh
@@ -33,6 +33,16 @@ if [ -z "${default_ssl_cert_file}" ]; then
         default_ssl_cert_file="/etc/ssl/ca-certificates.crt"
     elif [ -f "/etc/ca-certificates.crt" ]; then
         default_ssl_cert_file="/etc/ca-certificates.crt"
+    elif [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
+        default_ssl_cert_file="/etc/pki/tls/certs/ca-bundle.crt"
+    elif [ -f "/etc/ssl/ca-bundle.pem" ]; then
+        default_ssl_cert_file="/etc/ssl/ca-bundle.pem"
+    elif [ -f "/etc/pki/tls/cacert.pem" ]; then
+        default_ssl_cert_file="/etc/pki/tls/cacert.pem"
+    elif [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ]; then
+        default_ssl_cert_file="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+    elif [ -f "/etc/ssl/cert.pem" ]; then
+        default_ssl_cert_file="/etc/ssl/cert.pem"
     else
         echo "WARNING: Failed to locate ca-certificates.crt file!"
         echo


### PR DESCRIPTION
This removes vendored applications/libraries from the appimage
build leaving it up to the user to install required tools. By
removing vendored apps/libraries issues with compatiblity of tools
(like older ssh versions) and linking should be greatly reduced.
