### PR TITLE
Release and sync fixes

### DIFF
--- a/.ci/build-packages.sh
+++ b/.ci/build-packages.sh
@@ -318,7 +318,7 @@ if [ ! -z "${release}" ]; then
     upload_assets pkg/
 
     echo "Releasing new version of Vagrant to HashiCorp releases - v${vagrant_version}"
-    hashicorp_release pkg/
+    hashicorp_release pkg/ vagrant
 
     slack -m "New Vagrant release has been published! - *${vagrant_version}*\n\nAssets: https://releases.hashicorp.com/vagrant/${vagrant_version}\nStore: $(asset_location)"
 else

--- a/.ci/sync.sh
+++ b/.ci/sync.sh
@@ -10,6 +10,9 @@ export PATH="${PATH}:${root}/.ci"
 
 pushd "${root}" > "${output}"
 
+# Configure for hashibot
+hashibot_git
+
 if [ "${repo_name}" = "vagrant-installers" ]; then
     remote_repository="hashicorp/vagrant-builders"
 else


### PR DESCRIPTION
On release include product name so the default of the
local repository name is not used. Before running repository
sync, configure the local repository to the hashibot user.
