### PR TITLE
Use native Windows curl build by default

### DIFF
--- a/substrate/launcher/main.go
+++ b/substrate/launcher/main.go
@@ -336,22 +336,43 @@ func main() {
 			if debug {
 				log.Printf("launcher: path modification will prefer system bins.")
 			}
-			path = fmt.Sprintf(
-				"%s;%s;%s;%s",
-				filepath.Join(embeddedDir, mingwDir, "bin"),
-				path,
-				filepath.Join(embeddedDir, "bin"),
-				filepath.Join(embeddedDir, "usr", "bin"))
+			if os.Getenv("VAGRANT_DISABLE_WINCURL") != "" {
+				path = fmt.Sprintf(
+					"%s;%s;%s;%s",
+					path,
+					filepath.Join(embeddedDir, mingwDir, "bin"),
+					filepath.Join(embeddedDir, "usr", "bin"),
+					filepath.Join(embeddedDir, "bin"))
+			} else {
+				path = fmt.Sprintf(
+					"%s;%s;%s;%s",
+					path,
+					filepath.Join(embeddedDir, "bin"),
+					filepath.Join(embeddedDir, mingwDir, "bin"),
+					filepath.Join(embeddedDir, "usr", "bin"))
+			}
 		} else {
-			path = fmt.Sprintf(
-				"%s;%s;%s;%s",
-				filepath.Join(embeddedDir, mingwDir, "bin"),
-				filepath.Join(embeddedDir, "bin"),
-				filepath.Join(embeddedDir, "usr", "bin"),
-				path)
+			if os.Getenv("VAGRANT_DISABLE_WINCURL") != "" {
+				path = fmt.Sprintf(
+					"%s;%s;%s;%s",
+					filepath.Join(embeddedDir, mingwDir, "bin"),
+					filepath.Join(embeddedDir, "usr", "bin"),
+					filepath.Join(embeddedDir, "bin"),
+					path)
+			} else {
+				path = fmt.Sprintf(
+					"%s;%s;%s;%s",
+					filepath.Join(embeddedDir, "bin"),
+					filepath.Join(embeddedDir, mingwDir, "bin"),
+					filepath.Join(embeddedDir, "usr", "bin"),
+					path)
+			}
 		}
 	} else {
 		if preferSystem {
+			if debug {
+				log.Printf("launcher: path modification will prefer system bins.")
+			}
 			path = fmt.Sprintf("%s:%s",
 				path, filepath.Join(embeddedDir, "bin"))
 		} else {


### PR DESCRIPTION
    Use the native Windows curl by default so schannel can be
    used for tls which should resolve issues where users have
    custom certs installed on their system and Vagrant doesn't
    properly see them. Use of the Windows native curl can be
    disabled using the VAGRANT_DISABLE_WINCURL environment
    variable
