### PR TITLE
Fix preprocessor detection due to autoconf update

### DIFF
--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -406,6 +406,13 @@ curl -L -s -o libarchive.tar.gz "${libarchive_url}"
 tar -xzf libarchive.tar.gz
 pushd libarchive-*
 
+if [ "${host_os}" = "darwin" ]; then
+    conf_file=$(<configure.ac)
+    if [[ "${conf_file}" != *"AC_PROG_CPP"* ]]; then
+        sed -i.old 's/^AM_PROG_CC_C_O/AM_PROG_CC_C_O\'$'\nAC_PROG_CPP/' configure.ac
+    fi
+fi
+
 if [[ "${host_os}" = "linux" ]]; then
     export PATH=/usr/local/bin:$PATH
     PATH=/usr/local/bin:$PATH


### PR DESCRIPTION
Checks if `configure.ac` includes the correct macro and if
not will automatically add it. This will prevent it from
attempting modification after this fix is included in the
next release.

Reference: libarchive/libarchive#1481
