### PR TITLE
Update package naming and scripts

### DIFF
--- a/package/appimage/vagrant.yml
+++ b/package/appimage/vagrant.yml
@@ -1,6 +1,5 @@
 app: vagrant
 union: true
-#binpatch: true
 
 ingredients:
   dist: focal

--- a/package/appimage/vagrant_wrapper.sh
+++ b/package/appimage/vagrant_wrapper.sh
@@ -93,7 +93,7 @@ export VAGRANT_INSTALLER_EMBEDDED_DIR="${VAGRANT_ROOT_DIR}"
 export VAGRANT_PKG_CONFIG_PATH="${PKG_CONFIG_PATH}"
 export VAGRANT_RUBYLIB="${RUBYLIB}"
 
-if [ "${VAGRANT_PREFER_SYSTEM_BIN}" != "" -a "${VAGRANT_PREFER_SYSTEM_BIN}" != "0" ]; then
+if [[ "${VAGRANT_PREFER_SYSTEM_BIN}" != "" && "${VAGRANT_PREFER_SYSTEM_BIN}" != "0" ]]; then
     export PATH="${PATH}:${DIR}"
 else
     export PATH="${DIR}:${PATH}"
@@ -101,8 +101,7 @@ fi
 
 new_ld_library_path="${LD_LIBRARY_PATH}"
 
-command -v ldconfig > /dev/null
-if [ $? -eq 0 ]; then
+if command -v ldconfig > /dev/null; then
     extra_ld_path=$(ldconfig -N -X -v 2>&1 | grep "^/.*:$" | tr -d ":" | tr "\n" ":")
 else
     extra_ld_path="/lib:/lib64:/usr/lib:/usr/lib64"
@@ -121,17 +120,17 @@ unset PYTHONPATH
 
 # Before we get started, check that curl and SSH are available
 if [ ! -x "$(command -v curl)" ]; then
-    echo "WARNING: Failed to locate `curl` executable"
-    echo "  Vagrant relies on `curl` for handling assets. Please"
-    echo "  ensure that `curl` has been installed to prevent errors"
+    echo "WARNING: Failed to locate 'curl' executable"
+    echo "  Vagrant relies on 'curl' for handling assets. Please"
+    echo "  ensure that 'curl' has been installed to prevent errors"
     echo "  when Vagrant is uploading or downloading assets."
     echo
 fi
 
 if [ ! -x "$(command -v ssh)" ]; then
-    echo "WARNING: Failed to locate `ssh` executable"
-    echo "  Vagrant relies on the `ssh` command for connecting to"
-    echo "  guests. Please ensure that `ssh` has been installed to"
+    echo "WARNING: Failed to locate 'ssh' executable"
+    echo "  Vagrant relies on the 'ssh' command for connecting to"
+    echo "  guests. Please ensure that 'ssh' has been installed to"
     echo "  prevent error when Vagrant attempts to connect to guests."
 fi
 

--- a/package/package.ps1
+++ b/package/package.ps1
@@ -285,9 +285,9 @@ $contents | Out-File `
 #--------------------------------------------------------------------
 # Final path to output
 if ( $PackageArch -eq "64") {
-    $OutputPath = "vagrant_${VagrantVersion}_x86_64.msi"
+    $OutputPath = "vagrant_${VagrantVersion}_windows_amd64.msi"
 } else {
-    $OutputPath = "vagrant_${VagrantVersion}_i686.msi"
+    $OutputPath = "vagrant_${VagrantVersion}_windows_i686.msi"
 }
 
 $InstallerTmpDir = [System.IO.Path]::GetTempPath()

--- a/package/support/archlinux/PKGBUILD.local
+++ b/package/support/archlinux/PKGBUILD.local
@@ -1,6 +1,6 @@
 pkgname=hashicorp-vagrant
 pkgver="%VAGRANT_VERSION%"
-pkgrel=1
+pkgrel=%RELEASE_NUMBER%
 pkgdesc="Build and distribute virtualized development environments"
 arch=('x86_64')
 url="https://www.vagrantup.com"

--- a/package/support/install_vagrant.sh
+++ b/package/support/install_vagrant.sh
@@ -6,14 +6,17 @@
 # This is a wrapper that is able to install a version of Vagrant into
 # the substrate. Once this command runs, the substrate directory it is
 # pointed to is no longer valid.
-set -e
-set -x
+
+function fail() {
+    echo "ERROR: ${1}"
+    exit 1
+}
 
 function relpath() {
-    path_to=`readlink -f "$2"`
-    source=`readlink -f "$1"`
+    path_to="$(readlink -f "$2")"
+    source="$(readlink -f "$1")"
     rel=$(perl -MFile::Spec -e "print File::Spec->abs2rel(q($path_to),q($source))")
-    echo $rel
+    echo "${rel}"
 }
 
 # Verify arguments
@@ -22,10 +25,10 @@ if [ "$#" -ne "3" ]; then
   exit 1
 fi
 
-SUBSTRATE_DIR=$1
-EMBEDDED_DIR="$1/embedded"
-VAGRANT_REV=$2
-VERSION_OUTPUT=$3
+SUBSTRATE_DIR="${1}"
+EMBEDDED_DIR="${SUBSTRATE_DIR}/embedded"
+VAGRANT_REV="${2}"
+VERSION_OUTPUT="${3}"
 
 export GEM_COMMAND="${EMBEDDED_DIR}/bin/gem"
 
@@ -49,7 +52,8 @@ fi
 
 # Work in a temporary directory
 TMP_DIR=$(mktemp -d tmp.XXXXXXXXX)
-pushd $TMP_DIR
+pushd "${TMP_DIR}" ||
+    fail "Failed to move into temporary directory"
 
 if [ ! -f "${VAGRANT_GEM_PATH}" ]; then
     # Download Vagrant and extract
@@ -57,32 +61,36 @@ if [ ! -f "${VAGRANT_GEM_PATH}" ]; then
     SOURCE_PREFIX=${SOURCE_REPO/\//-}
     SOURCE_URL="https://api.github.com/repos/${SOURCE_REPO}/tarball/${VAGRANT_REV}"
     if [ -z "${VAGRANT_TOKEN}" ]; then
-        curl -L ${SOURCE_URL} > vagrant.tar.gz
+        curl -f -L "${SOURCE_URL}" > vagrant.tar.gz ||
+            fail "Failed to download Vagrant tarball"
     else
-        curl -L -u "${VAGRANT_TOKEN}:x-oauth-basic" ${SOURCE_URL} > vagrant.tar.gz
+        curl -f -L -u "${VAGRANT_TOKEN}:x-oauth-basic" "${SOURCE_URL}" > vagrant.tar.gz ||
+            fail "Failed to download Vagrant tarball"
     fi
-    rm -rf ${SOURCE_PREFIX}-*
-    tar xzf vagrant.tar.gz
+    rm -rf "${SOURCE_PREFIX}-"*
+    tar xzf vagrant.tar.gz || fail "Failed to unpack Vagrant tarball"
     rm vagrant.tar.gz
-    cd ${SOURCE_PREFIX}-*
+    pushd "${SOURCE_PREFIX}-"* || fail "Failed to enter Vagrant source directory"
 
-    # If we have a version file, use that. Otherwise, use a timestamp
-    # on version 0.1.
+    # If we have no version file, bail
     if [ ! -f "version.txt" ]; then
-        echo -n "0.1.0" > version.txt
+        fail "Could not locate version file in Vagrant source"
     fi
-    VERSION=$(cat version.txt | sed -e 's/\.[^0-9]*$//')
-    echo -n $VERSION >"${VERSION_OUTPUT}"
+    VERSION="$(<version.txt)"
+    echo -n "${VERSION}" > "${VERSION_OUTPUT}"
 
     # Build the gem
-    ${GEM_COMMAND} build vagrant.gemspec
-    cp vagrant-*.gem vagrant.gem
+    ${GEM_COMMAND} build vagrant.gemspec || fail "Failed to build Vagrant gem"
+    cp vagrant-*.gem vagrant.gem || fail "Failed to relocate Vagrant gem"
+    git submodule --init --recursive || fail "Failed to install submodule dependencies"
+    make bin || fail "Failed to build the vagrant-go binary"
+    mv vagrant vagrant-go || fail "Failed to relocate the vagrant-go binary"
 else
-    cp "${VAGRANT_GO_PATH}" ./vagrant-go
-    cp "${VAGRANT_GEM_PATH}" ./vagrant.gem
-    ${GEM_COMMAND} unpack ./vagrant.gem
-    VERSION=$(cat vagrant/version.txt | sed -e 's/\.[^0-9]*$//')
-    echo -n $VERSION >"${VERSION_OUTPUT}"
+    cp "${VAGRANT_GO_PATH}" ./vagrant-go || fail "Failed to relocate vagrant-go binary"
+    cp "${VAGRANT_GEM_PATH}" ./vagrant.gem || fail "Failed to relocate Vagrant gem"
+    ${GEM_COMMAND} unpack ./vagrant.gem || fail "Failed to unpack Vagrant gem"
+    VERSION="$(<vagrant/version.txt)"
+    echo -n "${VERSION}" > "${VERSION_OUTPUT}"
 fi
 
 # We want to use the system libxml/libxslt for Nokogiri
@@ -102,33 +110,38 @@ export PKG_CONFIG_PATH="${EMBEDDED_DIR}/lib/pkgconfig"
 
 mkdir -p "${EMBEDDED_DIR}/certs"
 # Install the pkg-config gem to ensure system can read the bundled *.pc files
-${GEM_COMMAND} install pkg-config --no-document -v "~> 1.1.7"
+${GEM_COMMAND} install pkg-config --no-document -v "~> 1.1.7" ||
+    fail "Failed to install pkg-config gem"
 
-${GEM_COMMAND} install vagrant.gem --no-document
+${GEM_COMMAND} install vagrant.gem --no-document ||
+    fail "Failed to install the vagrant gem"
 
 # Install extensions
 # ${GEM_COMMAND} install vagrant-share --force --no-document --conservative --clear-sources --source "https://gems.hashicorp.com"
 
 # Install Vagrant go binary to bin dir
-mv vagrant-go "${SUBSTRATE_DIR}"/bin/vagrant-go
+mv vagrant-go "${SUBSTRATE_DIR}"/bin/vagrant-go ||
+    fail "Failed to install the vagrant-go binary"
 
 # Setup the system plugins
-cat <<EOF >${EMBEDDED_DIR}/plugins.json
+cat <<EOF >"${EMBEDDED_DIR}/plugins.json"
 {
     "version": "1",
     "installed": {
     }
 }
 EOF
-chmod 0644 ${EMBEDDED_DIR}/plugins.json
+chmod 0644 "${EMBEDDED_DIR}/plugins.json" ||
+    fail "Could not set plugins.json permission"
 
 # Setup vagrant manifest
-cat <<EOF >${EMBEDDED_DIR}/manifest.json
+cat <<EOF >"${EMBEDDED_DIR}/manifest.json"
 {
     "vagrant_version": "${VERSION}"
 }
 EOF
-chmod 0644 ${EMBEDDED_DIR}/manifest.json
+chmod 0644 "${EMBEDDED_DIR}/manifest.json" ||
+    fail "Could not set manifest.json permission"
 
 # Darwin
 # if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -155,5 +168,7 @@ chmod 0644 ${EMBEDDED_DIR}/manifest.json
 # fi
 
 # Exit the temporary directory
+# (we really don't care if this fails)
+# shellcheck disable=SC2164
 popd
-rm -rf ${TMP_DIR}
+rm -rf "${TMP_DIR}"

--- a/package/support/package_centos.sh
+++ b/package/support/package_centos.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-set -e
+
+function fail() {
+    echo "ERROR: ${1}"
+    exit 1
+}
 
 # Verify arguments
 if [ "$#" -ne "2" ]; then
@@ -7,22 +11,31 @@ if [ "$#" -ne "2" ]; then
   exit 1
 fi
 
-SUBSTRATE_DIR=$1
-VAGRANT_VERSION=$2
-ARCH=$(arch | perl -ne 'chomp and print')
-OUTPUT_PATH="`pwd`/vagrant_${VAGRANT_VERSION}_${ARCH}.rpm"
+SUBSTRATE_DIR="${1}"
+VAGRANT_VERSION="${2}"
+if [ "$(arch)" = "x86_64" ]; then
+  ARCH="x86_64"
+else
+  ARCH="i686"
+fi
+if [ -z "${RELEASE_NUMBER}" ]; then
+  RELEASE_NUMBER="1"
+fi
+
+OUTPUT_PATH="$(pwd)/vagrant-${VAGRANT_VERSION}-${RELEASE_NUMBER}.${ARCH}.rpm"
 
 # Work in a temporary directory
 rm -rf package-staging
 mkdir -p package-staging
-STAGING_DIR=$(cd package-staging; pwd)
-pushd $STAGING_DIR
+pushd package-staging || fail "Could not enter staging directory"
+
+STAGING_DIR="$(pwd)"
 
 # Make some directories
 mkdir -p ./usr/bin
 mkdir -p ./opt/vagrant
-mv ${SUBSTRATE_DIR}/bin ./opt/vagrant
-mv ${SUBSTRATE_DIR}/embedded ./opt/vagrant
+mv "${SUBSTRATE_DIR}/bin" ./opt/vagrant || fail "Could not move substrate bin dir"
+mv "${SUBSTRATE_DIR}/embedded" ./opt/vagrant || fail "Could not move substrate embedded dir"
 
 # Create the Linux script proxy
 cat <<EOF >./usr/bin/vagrant
@@ -32,7 +45,7 @@ cat <<EOF >./usr/bin/vagrant
 
 /opt/vagrant/bin/vagrant "\$@"
 EOF
-chmod +x ./usr/bin/vagrant
+chmod +x ./usr/bin/vagrant || fail "Could not set vagrant script executable"
 
 # Create the Linux script proxy for vagrant-go
 cat <<EOF >./usr/bin/vagrant-go
@@ -42,12 +55,12 @@ cat <<EOF >./usr/bin/vagrant-go
 
 /opt/vagrant/bin/vagrant-go "\$@"
 EOF
-chmod +x ./usr/bin/vagrant-go
+chmod +x ./usr/bin/vagrant-go || fail "Could not set vagrant-go script executable"
 
 # Package it up!
-fpm -p ${OUTPUT_PATH} \
+fpm -p "${OUTPUT_PATH}" \
   -n vagrant \
-  -v $VAGRANT_VERSION \
+  -v "${VAGRANT_VERSION}" \
   -s dir \
   -t rpm \
   --prefix '/' \
@@ -57,9 +70,11 @@ fpm -p ${OUTPUT_PATH} \
   --url 'https://www.vagrantup.com' \
   --license 'MIT' \
   --description 'Vagrant is a tool for building and distributing development environments.' \
-  -C ${STAGING_DIR} \
-  .
+  -C "${STAGING_DIR}" \
+  . || fail "Failed to build package"
 
 # Exit the directory and clean it
+# (we really don't care if this fails)
+# shellcheck disable=SC2164
 popd
-rm -rf $STAGING_DIR
+rm -rf "${STAGING_DIR}"

--- a/package/support/package_ubuntu.sh
+++ b/package/support/package_ubuntu.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-set -e
+
+function fail() {
+    echo "ERROR: ${1}"
+    exit 1
+}
 
 # Verify arguments
 if [ "$#" -ne "2" ]; then
@@ -7,22 +11,31 @@ if [ "$#" -ne "2" ]; then
   exit 1
 fi
 
-SUBSTRATE_DIR=$1
-VAGRANT_VERSION=$2
-ARCH=$(arch | perl -ne 'chomp and print')
-OUTPUT_PATH="`pwd`/vagrant_${VAGRANT_VERSION}_${ARCH}.deb"
+SUBSTRATE_DIR="${1}"
+VAGRANT_VERSION="${2}"
+if [ "$(arch)" = "x86_64" ]; then
+  ARCH="amd64"
+else
+  ARCH="i686"
+fi
+if [ -z "${RELEASE_NUMBER}" ]; then
+  RELEASE_NUMBER="1"
+fi
+
+OUTPUT_PATH="$(pwd)/vagrant_${VAGRANT_VERSION}-${RELEASE_NUMBER}_${ARCH}.deb"
 
 # Work in a temporary directory
 rm -rf package-staging
 mkdir -p package-staging
-STAGING_DIR=$(cd package-staging; pwd)
-pushd $STAGING_DIR
+pushd package-staging || fail "Could not enter staging directory"
+
+STAGING_DIR="$(pwd)"
 
 # Make some directories
 mkdir -p ./usr/bin
 mkdir -p ./opt/vagrant
-mv ${SUBSTRATE_DIR}/bin ./opt/vagrant
-mv ${SUBSTRATE_DIR}/embedded ./opt/vagrant
+mv "${SUBSTRATE_DIR}/bin" ./opt/vagrant || fail "Could not move substrate bin dir"
+mv "${SUBSTRATE_DIR}/embedded" ./opt/vagrant || fail "Could not move substrate embedded dir"
 
 # Create the Linux script proxy
 cat <<EOF >./usr/bin/vagrant
@@ -32,7 +45,7 @@ cat <<EOF >./usr/bin/vagrant
 
 /opt/vagrant/bin/vagrant "\$@"
 EOF
-chmod +x ./usr/bin/vagrant
+chmod +x ./usr/bin/vagrant || fail "Could not set vagrant script executable"
 
 # Create the Linux script proxy for vagrant-go
 cat <<EOF >./usr/bin/vagrant-go
@@ -42,12 +55,12 @@ cat <<EOF >./usr/bin/vagrant-go
 
 /opt/vagrant/bin/vagrant-go "\$@"
 EOF
-chmod +x ./usr/bin/vagrant-go
+chmod +x ./usr/bin/vagrant-go || fail "Could not set vagrant-go script executable"
 
 # Package it up!
-fpm -p ${OUTPUT_PATH} \
+fpm -p "${OUTPUT_PATH}" \
   -n vagrant \
-  -v $VAGRANT_VERSION \
+  -v "${VAGRANT_VERSION}" \
   -s dir \
   -t deb \
   --prefix '/' \
@@ -56,8 +69,10 @@ fpm -p ${OUTPUT_PATH} \
   --epoch 1 \
   --deb-user root \
   --deb-group root \
-  .
+  . || fail "Failed to build package"
 
 # Exit the directory and clean it
+# (we really don't care if this fails)
+# shellcheck disable=SC2164
 popd
-rm -rf $STAGING_DIR
+rm -rf "${STAGING_DIR}"


### PR DESCRIPTION
This provides a few updates to the package generation.
Package name patterns have been adjusted to match desired
formats. Scripts have been cleaned up to properly wrap
variables and explicitly fail when expected. Install
vagrant support script has been updated to properly handle
repository tarball based installation including building
the vagrant-go binary. 
