### PR TITLE
Couple fixes for arch and appimage

### DIFF
--- a/package/appimage.sh
+++ b/package/appimage.sh
@@ -24,7 +24,7 @@ if [ ! -f "${gem_path}" ]; then
     exit 1
 fi
 
-WORK_DIR="$(mktemp -d tmp.XXXXXXXXX)"
+WORK_DIR="$(mktemp -d tmp.XXXXXXXXX -p "$(pwd)")"
 pushd "${WORK_DIR}" || fail "Could not enter work directory"
 
 # Copy in required files

--- a/package/appimage/pkg2appimage
+++ b/package/appimage/pkg2appimage
@@ -31,7 +31,6 @@ fi
 
 # Halt on errors
 set -e
-set -x
 
 # Check dependencies
 which wget >/dev/null 2>&1 || ( echo wget missing && exit 1 )

--- a/package/support/install_vagrant.sh
+++ b/package/support/install_vagrant.sh
@@ -42,16 +42,20 @@ VAGRANT_GEM_PATH="${DIR}/../vagrant.gem"
 if [[ "${OSTYPE}" == "darwin"* ]]; then
     VAGRANT_GO_PATH=("${DIR}/../vagrant-go_"*darwin*)
 else
-    ARCH=$(arch | perl -ne 'chomp and print')
-    if [[ "${ARCH}" == "x86_64" ]]; then
-        VAGRANT_GO_PATH=("${DIR}/../vagrant-go_"*linux_amd64)
+    if command -v arch; then
+        ARCH=$(arch | perl -ne 'chomp and print')
+        if [[ "${ARCH}" == "x86_64" ]]; then
+            VAGRANT_GO_PATH=("${DIR}/../vagrant-go_"*linux_amd64)
+        else
+            VAGRANT_GO_PATH=("${DIR}/../vagrant-go_"*linux_386)
+        fi
     else
-        VAGRANT_GO_PATH=("${DIR}/../vagrant-go_"*linux_386)
+        VAGRANT_GO_PATH=("${DIR}/../vagrant-go_"*linux_amd64)
     fi
 fi
 
 # Work in a temporary directory
-TMP_DIR=$(mktemp -d tmp.XXXXXXXXX)
+TMP_DIR="$(mktemp -d tmp.XXXXXXXXX -p "$(pwd)")"
 pushd "${TMP_DIR}" ||
     fail "Failed to move into temporary directory"
 

--- a/package/support/package_archlinux.sh
+++ b/package/support/package_archlinux.sh
@@ -23,7 +23,7 @@ while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # Work in a temporary directory
-TMP_DIR="$(mktemp -d tmp.XXXXXXXXX)"
+TMP_DIR="$(mktemp -d tmp.XXXXXXXXX -p "$(pwd)")"
 pushd "${TMP_DIR}" || fail "Failed to move to temporary working directory"
 
 cp "${DIR}/archlinux/PKGBUILD.local" ./PKGBUILD || fail "Failed to get PKGBUILD file"


### PR DESCRIPTION
Couple quick fixes for appimage generation where
the temporary directory wasn't being generated
with the full path returned. We also don't have
`arch` installed on the archlinux box, but we
can just force 64bit if the command isn't found.
