### PR TITLE
Better substrate caching

### DIFF
--- a/substrate/deps.sh
+++ b/substrate/deps.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This file contains version information for all dependencies
+# required by the Vagrant substrates. Substrates are built
+# and cached based on the git commit id. This allows substrates
+# to be reused until a new version requires an updated substrate
+# to be created. Some substrates (like windows) are built using
+# a package manager and have more updates applied outside our
+# view. Update the date below to force a new substrate build
+# when no libraries need to be updated:
+#
+# FORCE REBUILD: 2022-08-11 16:52:43-07:00
+
+autoconf_version="2.71"
+curl_version="7.84.0"
+libarchive_version="3.6.1"
+libffi_version="3.4.2"
+libgcrypt_version="1.10.1"
+libgmp_version="6.2.1"
+libgpg_error_version="1.45"
+libiconv_version="1.17"
+# Need up update gcc version to use libssh2 1.9.0+
+libssh2_version="1.8.0"
+libxml2_version="2.9.14"
+libxslt_version="1.1.35"
+libyaml_version="0.2.5"
+openssl_version="1.1.1q"
+readline_version="8.1.2"
+ruby_version="2.7.6"
+xz_version="5.2.5"
+zlib_version="1.2.12"
+
+# Used for centos builds
+m4_version="1.4.18"
+automake_version="1.16.3"
+libtool_version="2.4.6"
+patchelf_version="0.9"
+libxcrypt_version="4.4.18"

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -1,36 +1,41 @@
 #!/usr/bin/env bash
 
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/substrate/deps.sh"
+
 #### Software dependencies
 
 dep_cache="https://vagrant-public-cache.s3.amazonaws.com/installers/dependencies"
 
 #### Update these as required
-autoconf_file="autoconf-2.71.tar.gz"
-curl_file="curl-7.84.0.tar.gz"                # https://curl.haxx.se/download/curl-${curl_version}.tar.gz
-libarchive_file="libarchive-3.6.1.tar.gz"    # https://github.com/libarchive/libarchive/archive/v${libarchive_version}.tar.gz
-libffi_file="libffi-3.4.2.tar.gz"               # https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz ftp://sourceware.org/pub/libffi/libffi-${libffi_version}.tar.gz
-libgcrypt_file="libgcrypt-1.10.1.tar.bz2"      # https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${libgcrypt_version}.tar.bz2
-libgmp_file="gmp-6.2.1.tar.bz2"               # https://ftp.gnu.org/gnu/gmp/gmp-${libgmp_version}.tar.bz2
-libgpg_error_file="libgpg-error-1.45.tar.bz2" # https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${libgpg_error_version}.tar.bz2
-libiconv_file="libiconv-1.17.tar.gz"          # https://mirrors.kernel.org/gnu/libiconv/libiconv-${libiconv_version}.tar.gz
+autoconf_file="autoconf-${autoconf_version}.tar.gz"
+curl_file="curl-${curl_version}.tar.gz"                # https://curl.haxx.se/download/curl-${curl_version}.tar.gz
+libarchive_file="libarchive-${libarchive_version}.tar.gz"    # https://github.com/libarchive/libarchive/archive/v${libarchive_version}.tar.gz
+libffi_file="libffi-${libffi_version}.tar.gz"               # https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz ftp://sourceware.org/pub/libffi/libffi-${libffi_version}.tar.gz
+libgcrypt_file="libgcrypt-${libgcrypt_version}.tar.bz2"      # https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${libgcrypt_version}.tar.bz2
+libgmp_file="gmp-${libgmp_version}.tar.bz2"               # https://ftp.gnu.org/gnu/gmp/gmp-${libgmp_version}.tar.bz2
+libgpg_error_file="libgpg-error-${libgpg_error_version}.tar.bz2" # https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${libgpg_error_version}.tar.bz2
+libiconv_file="libiconv-${libiconv_version}.tar.gz"          # https://mirrors.kernel.org/gnu/libiconv/libiconv-${libiconv_version}.tar.gz
 # Need up update gcc version to use libssh2 1.9.0+
-libssh2_file="libssh2-1.8.0.tar.gz"           # https://www.libssh2.org/download/libssh2-${libssh2_version}.tar.gz
-libxml2_file="libxml2-2.9.14.tar.xz"          # https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.14/libxml2-v2.9.14.tar.gz ftp://xmlsoft.org/libxml2/libxml2-${libxml2_version}.tar.gz
-libxslt_file="libxslt-1.1.35.tar.xz"          # https://gitlab.gnome.org/GNOME/libxslt/-/archive/v1.1.35/libxslt-v1.1.35.tar.gz ftp://xmlsoft.org/libxml2/libxslt-${libxslt_version}.tar.gz
-libyaml_file="yaml-0.2.5.tar.gz"              # http://pyyaml.org/download/libyaml/yaml-${libyaml_version}.tar.gz
-openssl_file="openssl-1.1.1q.tar.gz"          # https://www.openssl.org/source/openssl-${openssl_version}.tar.gz
-readline_file="readline-8.1.2.tar.gz"           # https://ftpmirror.gnu.org/readline/readline-${readline_version}.tar.gz
-ruby_file="ruby-2.7.6.zip"                    # https://cache.ruby-lang.org/pub/ruby/${ruby_short_version}/ruby-${ruby_version}.zip
-xz_file="xz-5.2.5.tar.gz"                     # https://tukaani.org/xz/xz-${xz_version}.tar.gz
-zlib_file="zlib-1.2.12.tar.gz"                # http://zlib.net/zlib-${zlib_version}.tar.gz
+libssh2_file="libssh2-${libssh2_version}.tar.gz"           # https://www.libssh2.org/download/libssh2-${libssh2_version}.tar.gz
+libxml2_file="libxml2-${libxml2_version}.tar.xz"          # https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.14/libxml2-v2.9.14.tar.gz ftp://xmlsoft.org/libxml2/libxml2-${libxml2_version}.tar.gz
+libxslt_file="libxslt-${libxslt_version}.tar.xz"          # https://gitlab.gnome.org/GNOME/libxslt/-/archive/v1.1.35/libxslt-v1.1.35.tar.gz ftp://xmlsoft.org/libxml2/libxslt-${libxslt_version}.tar.gz
+libyaml_file="yaml-${libyaml_version}.tar.gz"              # http://pyyaml.org/download/libyaml/yaml-${libyaml_version}.tar.gz
+openssl_file="openssl-${openssl_version}.tar.gz"          # https://www.openssl.org/source/openssl-${openssl_version}.tar.gz
+readline_file="readline-${readline_version}.tar.gz"           # https://ftpmirror.gnu.org/readline/readline-${readline_version}.tar.gz
+ruby_file="ruby-${ruby_version}.zip"                    # https://cache.ruby-lang.org/pub/ruby/${ruby_short_version}/ruby-${ruby_version}.zip
+xz_file="xz-${xz_version}.tar.gz"                     # https://tukaani.org/xz/xz-${xz_version}.tar.gz
+zlib_file="zlib-${zlib_version}.tar.gz"                # http://zlib.net/zlib-${zlib_version}.tar.gz
 
 # Used for centos builds
-m4_file="m4-1.4.18.tar.gz"                # https://ftp.gnu.org/gnu/m4/m4-${VERSION}.tar.gz
-automake_file="automake-1.16.3.tar.gz"    # https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.gz
-libtool_file="libtool-2.4.6.tar.gz"       # https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.gz
-patchelf_file="patchelf-0.9.tar.gz"       # https://nixos.org/releases/patchelf/patchelf-${VERSION}/patchelf-${VERSION}.tar.gz
-libxcrypt_file="libxcrypt-v4.4.18.tar.gz" # https://github.com/besser82/libxcrypt/archive/v${VERSION}.tar.gz
-
+m4_file="m4-${m4_version}.tar.gz"                # https://ftp.gnu.org/gnu/m4/m4-${VERSION}.tar.gz
+automake_file="automake-${automake_version}.tar.gz"    # https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.gz
+libtool_file="libtool-${libtool_version}.tar.gz"       # https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.gz
+patchelf_file="patchelf-${patchelf_version}.tar.gz"       # https://nixos.org/releases/patchelf/patchelf-${VERSION}/patchelf-${VERSION}.tar.gz
+libxcrypt_file="libxcrypt-v${libxcrypt_version}.tar.gz" # https://github.com/besser82/libxcrypt/archive/v${VERSION}.tar.gz
 
 macos_deployment_target="10.9"
 


### PR DESCRIPTION
This PR updates the caching strategy for substrate
builds to utilize the commit id of the substrate
directory instead of the root directory. This allows
for changes to occur outside the substrate directory
and not require the substrate assets be rebuilt
each time.

Dependency version information was also extracted
out into a separate file which is then used by
both both nix and win builds to help keep things
consistent (windows builds only use a subset of the list)
