### PR TITLE
Revert AppImage build to trusty host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ build_boxes = [
 ]
 
 box_mappings = {
-  'appimage' => 'bento/ubuntu-20.04',
+  'appimage' => 'ubuntu-14.04',
   'appimage-i386' => 'ubuntu-14.04-i386',
 }
 

--- a/package/appimage/vagrant.yml
+++ b/package/appimage/vagrant.yml
@@ -2,16 +2,14 @@ app: vagrant
 union: true
 
 ingredients:
-  dist: focal
+  dist: bionic
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ focal main universe
-    - deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main universe
-    - deb http://us.archive.ubuntu.com/ubuntu/ focal-backports main universe
-    - deb http://us.archive.ubuntu.com/ubuntu/ focal-security main universe
-  ppas:
-    - brightbox/ruby-ng
+    - deb http://us.archive.ubuntu.com/ubuntu/ bionic main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ bionic-updates main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ bionic-backports main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ bionic-security main universe
   debs:
-    - "${DEB_FILE}"
+    - "${VAGRANT_DEB_FILE}"
 
 script:
   - echo "[Desktop Entry]" > vagrant.desktop
@@ -23,13 +21,18 @@ script:
   - echo "Terminal=true" >> vagrant.desktop
   - touch app.png
   - rm -f lib/x86_64-linux-gnu/libtinfo.so*
-  - mkdir -p usr/gembundle
-  - GEM_PATH=usr/gembundle GEM_HOME=usr/gembundle usr/bin/gem2.7 install rubygems-update --no-document
-  - GEM_PATH=usr/gembundle GEM_HOME=usr/gembundle usr/bin/gem2.7 install "${WORK_DIR}/vagrant.gem" --no-document
-  - GEM_PATH=usr/gembundle GEM_HOME=usr/gembundle usr/bin/gem2.7 install pkg-config --no-document
+  - mkdir -p gems
+  - LD_LIBRARY_PATH="usr/lib:usr/lib64" GEM_PATH="gems" GEM_HOME="gems" usr/bin/gem install "${WORK_DIR}/vagrant.gem" --no-document
+  - LD_LIBRARY_PATH="usr/lib:usr/lib64" GEM_PATH="gems" GEM_HOME="gems" usr/bin/gem install pkg-config --no-document
   - cp "${WORK_DIR}/vagrant_wrapper.sh" usr/bin/vagrant
   - chmod a+x usr/bin/vagrant
   - rm -rf usr/share/man
   - rm -rf usr/share/info
-  - rm -rf usr/gembundle/cache
-  - mv usr/lib/x86_64-linux-gnu/pkgconfig usr/lib/x86_64-linux-gnu/pkgconfig-int
+  - rm -rf gems/cache
+  - rm -rf gems/gems/grpc-*-x86_64-linux/third_party
+  - rm -rf gems/gems/grpc-*-x86_64-linux/src/ruby/lib/grpc/2.{5,6}
+  - rm -rf gems/gems/grpc-*-x86_64-linux/src/ruby/lib/grpc/3.*
+  - rm -rf gems/gems/grpc-*-x86_64-linux/src/ruby/lib/grpc/grpc_c.so
+  - rm -rf gems/gems/grpc-*-x86_64-linux/src/core/ext/upb-generated
+  - rm -rf gems/gems/grpc-*-x86_64-linux/src/core/ext/upbdefs-generated
+  - rm -rf usr/lib/ruby/*/rdoc

--- a/package/appimage/vagrant_wrapper.sh
+++ b/package/appimage/vagrant_wrapper.sh
@@ -52,15 +52,13 @@ if [ -z "${default_ssl_cert_file}" ]; then
     fi
 fi
 
-RUBY_VERSION="2.7"
-
 unset RUBYLIB
 unset RUBYOPT
 export VAGRANT_BIN_DIR="${DIR}"
 export VAGRANT_USR_DIR="$( cd -P "$( dirname "$VAGRANT_BIN_DIR" )" && pwd )"
 export VAGRANT_ROOT_DIR="$( cd -P "$( dirname "$VAGRANT_USR_DIR" )" && pwd )"
-export GEM_HOME="${VAGRANT_USR_DIR}/gembundle"
-export GEM_PATH="${VAGRANT_USR_DIR}/gembundle"
+export GEM_HOME="${VAGRANT_ROOT_DIR}/gems"
+export GEM_PATH="${VAGRANT_ROOT_DIR}/gems"
 
 # Set our SSL certificate locations unless they are already set
 if [ -z "${SSL_CERT_FILE}" ]; then
@@ -134,4 +132,12 @@ if [ ! -x "$(command -v ssh)" ]; then
     echo "  prevent error when Vagrant attempts to connect to guests."
 fi
 
-"${VAGRANT_BIN_DIR}/ruby${RUBY_VERSION}" -- "${VAGRANT_USR_DIR}/gembundle/bin/vagrant" "$@"
+if [ ! -x "$(command -v bsdtar)" ]; then
+    echo "WARNING: Failed to locate 'bsdtar' executable"
+    echo "  Vagrant relies on the 'bsdtar' command for packing and"
+    echo "  unpacking Vagrant boxes. Please ensure that 'bsdtar' has"
+    echo "  been installed to prevent errors when Vagrant attempts to"
+    echo "  unpack or package a box."
+fi
+
+"${VAGRANT_USR_DIR}/bin/ruby" -- "${GEM_PATH}/bin/vagrant" "$@"

--- a/package/vagrant-scripts/appimage.sh
+++ b/package/vagrant-scripts/appimage.sh
@@ -2,14 +2,9 @@
 
 set -e
 
-# NOTE: Remove this once added to packer template
-#       and new box is available
-apt-get update
-apt-get install -yq libcairo2-dev
-
-/vagrant/package/appimage.sh
+/vagrant/package/appimage.sh "/vagrant/substrate-assets/substrate_ubuntu_$(uname -m).zip"
 
 pkg_dir=${VAGRANT_PACKAGE_OUTPUT_DIR:-"pkg"}
-mkdir -p /vagrant/${pkg_dir}
-chown vagrant:vagrant *.zip
-mv *.zip /vagrant/${pkg_dir}
+mkdir -p "/vagrant/${pkg_dir}"
+chown vagrant:vagrant ./*.zip
+mv ./*.zip "/vagrant/${pkg_dir}"


### PR DESCRIPTION
These changes revert the AppImage build to use Ubuntu Trusty (14.04)
as the host for building. This allows for the executable to be used
on older distributions. Regular package substrate is reused to provide
the needed Ruby and dependencies.

Fixes hashicorp/vagrant#12842
