### PR TITLE
Update ruby builds for darwin

### DIFF
--- a/package/support/package_darwin.sh
+++ b/package/support/package_darwin.sh
@@ -11,7 +11,7 @@ if [ "$#" -ne "2" ]; then
   exit 1
 fi
 
-macos_deployment_target="10.9"
+macos_deployment_target="10.11"
 
 sdk_root="/Library/Developer/CommandLineTools/SDKs"
 sdk_path="${sdk_root}/MacOSX.sdk"

--- a/package/vagrant-scripts/osx.sh
+++ b/package/vagrant-scripts/osx.sh
@@ -4,12 +4,6 @@ export PATH="/usr/local/bin:$PATH"
 
 # su vagrant -l -c 'brew update'
 
-# Move the SDK into the developer section
-sdk="/Users/vagrant/SDKs/MacOSX10.9.sdk"
-if [ -d "${sdk}" ]; then
-    mv "${sdk}" /Library/Developer/CommandLineTools/SDKs/
-fi
-
 chmod 755 /vagrant/package/package.sh
 
 set -e

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -32,7 +32,7 @@ zlib_file="zlib-${zlib_version}.tar.gz"                # http://zlib.net/zlib-${
 # Used for centos builds
 libxcrypt_file="libxcrypt-v4.4.28.tar.gz" # https://github.com/besser82/libxcrypt/archive/v${VERSION}.tar.gz
 
-macos_deployment_target="10.9"
+macos_deployment_target="10.11"
 
 function echo_stderr {
     (>&2 echo "$@")
@@ -407,10 +407,11 @@ curl -f -L -s -o ruby.zip "${ruby_url}"
 unzip -q ruby.zip
 pushd ruby-*
 o_cflags="${CFLAGS}"
-export CFLAGS="${CFLAGS} -I./include -O3 -std=c99"
-./configure --prefix="${embed_dir}" --disable-debug --disable-dependency-tracking --disable-install-doc \
-            --enable-shared --with-opt-dir="${embed_dir}" --enable-load-relative
-make && make install
+export CFLAGS="${CFLAGS} -I./include"
+./configure --prefix="${embed_dir}" --disable-debug --disable-dependency-tracking \
+    --disable-install-doc --enable-shared --with-opt-dir="${embed_dir}" --enable-load-relative
+make
+make install
 export CFLAGS="${o_cflags}"
 popd
 

--- a/substrate/vagrant-scripts/osx.sh
+++ b/substrate/vagrant-scripts/osx.sh
@@ -17,12 +17,6 @@ su vagrant -l -c 'brew install wget'
 #export SSL_CERT_FILE=/usr/local/etc/openssl/cacert.pem
 export PATH="$PATH:/usr/local/bin:/usr/local/go/bin"
 
-# Move the SDK into the developer section
-sdk="/Users/vagrant/SDKs/MacOSX10.9.sdk"
-if [ -d "${sdk}" ]; then
-    mv "${sdk}" /Library/Developer/CommandLineTools/SDKs/
-fi
-
 set -e
 
 /vagrant/substrate/run.sh "/vagrant/${OUTPUT_DIR}"


### PR DESCRIPTION
- Updates the macos sdk to use v10.11. This is required for building Ruby 3.x.
- Separate the `make` and `make install` step for building ruby. Previously this was swallowing up errors.

ref:
https://trac.macports.org/ticket/64349
https://bugs.ruby-lang.org/issues/18556