### PR TITLE
Include substrate identifier in package identifier

### DIFF
--- a/.ci/arch-build-information
+++ b/.ci/arch-build-information
@@ -19,7 +19,8 @@ run_sha="$(git log --format=%h -1 ./substrate/run.sh)" ||
 deps_sha="$(git log --format=%h -1 ./substrate/deps.sh)" ||
     failure "Could not generate commit sha for ./substrate/deps.sh"
 
-sub_cache_base="substrate-${run_sha}+${deps_sha}"
+sub_id="${run_sha}+${deps_sha}"
+sub_cache_base="substrate-${sub_id}"
 
 sub="arch-${sub_cache_base}"
 printf "arch-substrate-id=%s\n" "${sub}" >> "${GITHUB_OUTPUT}"
@@ -32,7 +33,7 @@ pkg_sha="$(git log --format=%h -1 ./package/build-archlinux)" ||
 pkg_support_sha="$(git log --format=%h -1 ./package/support/archlinux)" ||
     failure "Could not generate commit sha for ./package/support/archlinux"
 vagrant_sha="${VAGRANT_SHASUM:0:10}"
-pkg_base="${vagrant_sha}+${pkg_sha}+${pkg_support_sha}"
+pkg_base="${vagrant_sha}+${pkg_sha}+${pkg_support_sha}-${sub_id}"
 
 inst="arch-install-${pkg_base}"
 printf "arch-install-id=%s\n" "${inst}" >> "${GITHUB_OUTPUT}"

--- a/.ci/deb-build-information
+++ b/.ci/deb-build-information
@@ -19,7 +19,8 @@ run_sha="$(git log --format=%h -1 ./substrate/run.sh)" ||
 deps_sha="$(git log --format=%h -1 ./substrate/deps.sh)" ||
     failure "Could not generate commit sha for ./substrate/deps.sh"
 
-sub_cache_base="substrate-${run_sha}+${deps_sha}"
+sub_id="${run_sha}+${deps_sha}"
+sub_cache_base="substrate-${sub_id}"
 
 sub32="deb-${sub_cache_base}-32"
 printf "deb-32-substrate-id=%s\n" "${sub32}" >> "${GITHUB_OUTPUT}"
@@ -37,7 +38,7 @@ pkg_sha="$(git log --format=%h -1 ./package/build-deb)" ||
 pkg_support_sha="$(git log --format=%h -1 ./package/support/deb)" ||
     failure "Could not generate commit sha for ./package/support/deb"
 vagrant_sha="${VAGRANT_SHASUM:0:10}"
-pkg_base="${vagrant_sha}+${pkg_sha}+${pkg_support_sha}"
+pkg_base="${vagrant_sha}+${pkg_sha}+${pkg_support_sha}-${sub_id}"
 
 inst32="deb-install-${pkg_base}-32"
 printf "deb-32-install-id=%s\n" "${inst32}" >> "${GITHUB_OUTPUT}"

--- a/.ci/macos-build-information
+++ b/.ci/macos-build-information
@@ -19,7 +19,8 @@ run_sha="$(git log --format=%h -1 ./substrate/run.sh)" ||
 deps_sha="$(git log --format=%h -1 ./substrate/deps.sh)" ||
     failure "Could not generate commit sha for ./substrate/deps.sh"
 
-sub_cache_base="substrate-${run_sha}+${deps_sha}"
+sub_id="${run_sha}+${deps_sha}"
+sub_cache_base="substrate-${sub_id}"
 
 sub_arm_unsigned_id="${sub_cache_base}-arm-unsigned"
 printf "substrate-arm-unsigned-id=%s\n" "${sub_arm_unsigned_id}" >> "${GITHUB_OUTPUT}"
@@ -54,7 +55,8 @@ pkg_sha="$(git log --format=%h -1 ./package/darwin)" ||
 pkg_support_sha="$(git log --format=%h -1 ./package/support/darwin)" ||
     failure "Could not generate commit sha for ./package/support/darwin"
 
-pkg_cache_base="pkg-${VAGRANT_SHASUM:0:10}_${pkg_sha}+${pkg_support_sha}"
+pkg_id="${pkg_sha}+${pkg_support_sha}"
+pkg_cache_base="pkg-${VAGRANT_SHASUM:0:10}_${pkg_id}"
 
 gems_unsigned_id="${pkg_cache_base}-gems-unsigned"
 printf "gems-unsigned-id=%s\n" "${gems_unsigned_id}" >> "${GITHUB_OUTPUT}"
@@ -78,23 +80,25 @@ if github_draft_release_exists "${repo_name}" "${corepkg_signed_id}"; then
     printf "core-pkg-signed-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
 
-instpkg_unsigned_id="${pkg_cache_base}-installer-pkg-unsigned"
+inst_id="inst-${sub_id}-${pkg_id}"
+
+instpkg_unsigned_id="${inst_id}-pkg-unsigned"
 printf "installer-pkg-unsigned-id=%s\n" "${instpkg_unsigned_id}" >> "${GITHUB_OUTPUT}"
 if github_draft_release_exists "${repo_name}" "${instpkg_unsigned_id}"; then
     printf "installer-pkg-unsigned-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
-instpkg_signed_id="${pkg_cache_base}-installer-pkg-signed"
+instpkg_signed_id="${inst_id}-pkg-signed"
 printf "installer-pkg-signed-id=%s\n" "${instpkg_signed_id}" >> "${GITHUB_OUTPUT}"
 if github_draft_release_exists "${repo_name}" "${instpkg_signed_id}"; then
     printf "installer-pkg-signed-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
 
-dmg_unsigned_id="${pkg_cache_base}-dmg-unsigned"
+dmg_unsigned_id="${inst_id}-dmg-unsigned"
 printf "dmg-unsigned-id=%s\n" "${dmg_unsigned_id}" >> "${GITHUB_OUTPUT}"
 if github_draft_release_exists "${repo_name}" "${dmg_unsigned_id}"; then
     printf "dmg-unsigned-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
-dmg_signed_id="${pkg_cache_base}-dmg-signed"
+dmg_signed_id="${inst_id}-dmg-signed"
 printf "dmg-signed-id=%s\n" "${dmg_signed_id}" >> "${GITHUB_OUTPUT}"
 if github_draft_release_exists "${repo_name}" "${dmg_signed_id}"; then
     printf "dmg-signed-exists=true\n" >> "${GITHUB_OUTPUT}"

--- a/.ci/rpm-build-information
+++ b/.ci/rpm-build-information
@@ -19,7 +19,8 @@ run_sha="$(git log --format=%h -1 ./substrate/run.sh)" ||
 deps_sha="$(git log --format=%h -1 ./substrate/deps.sh)" ||
     failure "Could not generate commit sha for ./substrate/deps.sh"
 
-sub_cache_base="substrate-${run_sha}+${deps_sha}"
+sub_id="${run_sha}+${deps_sha}"
+sub_cache_base="substrate-${sub_id}"
 
 sub32="rpm-${sub_cache_base}-32"
 printf "rpm-32-substrate-id=%s\n" "${sub32}" >> "${GITHUB_OUTPUT}"
@@ -37,7 +38,7 @@ pkg_sha="$(git log --format=%h -1 ./package/build-rpm)" ||
 pkg_support_sha="$(git log --format=%h -1 ./package/support/rpm)" ||
     failure "Could not generate commit sha for ./package/support/rpm"
 vagrant_sha="${VAGRANT_SHASUM:0:10}"
-pkg_base="${vagrant_sha}+${pkg_sha}+${pkg_support_sha}"
+pkg_base="${vagrant_sha}+${pkg_sha}+${pkg_support_sha}-${sub_id}"
 
 inst32="rpm-install-${pkg_base}-32"
 printf "rpm-32-install-id=%s\n" "${inst32}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
The substrate identifier needs to be included in the package identifier
so that if the package has already been built, but a new substrate
artifact is build, then it will properly result in a new package
artifact being built.
