### PR TITLE
Fixes for the macOS build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -70,6 +70,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - name: Install Ruby
         run: sudo apt-get install -yq ruby
         env:
@@ -92,6 +96,13 @@ jobs:
         with:
           name: vagrant-rubygem
           path: ./gem
+      - name: Build launchers
+        run: make bin/launcher/darwin
+      - name: Store Launchers
+        uses: actions/upload-artifact@v3
+        with:
+          name: vagrant-launchers
+          path: ./bin
   build-arm-substrate:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.substrate-arm-unsigned-exists != 'true' }}
     runs-on: macos-latest
@@ -111,6 +122,11 @@ jobs:
           sudo chown "${username}" /opt/vagrant || exit
       - name: Code Checkout
         uses: actions/checkout@v3
+      - name: Fetch Launchers
+        uses: actions/download-artifact@v3
+        with:
+          name: vagrant-launchers
+          path: ./bin
       - name: Build ARM substrate
         run: ./substrate/run.sh ./artifacts
         env:
@@ -139,6 +155,11 @@ jobs:
           sudo chown "${username}" /opt/vagrant || exit
       - name: Code Checkout
         uses: actions/checkout@v3
+      - name: Fetch Launchers
+        uses: actions/download-artifact@v3
+        with:
+          name: vagrant-launchers
+          path: ./bin
       - name: Build x86 substrate
         run: ./substrate/run.sh ./artifacts
         env:

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -669,6 +669,7 @@ if needs_build "${tracker_file}" "curl"; then
     pushd curl-* > /dev/null || exit
     ./configure --prefix="${embed_dir}" --disable-dependency-tracking --without-libidn2 \
         --disable-ldap --with-libssh2 --with-ssl --enable-shared --disable-static \
+        --without-nghttp2 --without-nghttp3 \
         "${cross_configure[@]}" || exit
     make || exit
     make install || exit

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -155,7 +155,11 @@ if [ -z "${ENABLE_REBUILD}" ]; then
     cache_dir="$(pwd)" || exit
     popd > /dev/null || exit
     info "   * Rebuild support is currently disabled"
-    rm -rf "${build_dir:?}" || exit
+    # Skip build dir removal for darwin; it requires sudo and it is already
+    # done in the "Prep filesystem" step in build-macos.yml
+    if [[ "${host_os}" != "darwin" ]]; then
+        rm -rf "${build_dir:?}" || exit
+    fi
 else
     info "   * Rebuild support is currently enabled"
     cache_dir="./vagrant-substrate-cache-rebuild-enabled"


### PR DESCRIPTION
1. Add in launchers
2. Skip a cleanup step that was resulting in permissions errors
3. Remove nghttp to resolve linking errors on amd64 mac