### PR TITLE
Add libcrypt into appimage

### DIFF
--- a/package/appimage/excludelist
+++ b/package/appimage/excludelist
@@ -10,7 +10,7 @@ ld-linux-x86-64.so.2
 libanl.so.1
 libBrokenLocale.so.1
 libcidn.so.1
-libcrypt.so.1
+# libcrypt.so.1 # Not part of glibc anymore as of Fedora 30. See https://github.com/slic3r/Slic3r/issues/4798 and https://pagure.io/fedora-docs/release-notes/c/01d74b33564faa42959c035e1eee286940e9170e?branch=f28
 libc.so.6
 libdl.so.2
 libm.so.6


### PR DESCRIPTION
Upstream no longer excludes it and systems with libcrypt that do not include backwards compatibility break when running the appimage.

For details, see: https://github.com/besser82/libxcrypt/#compatibility-notes

Refs https://github.com/hashicorp/vagrant-installers/issues/254