### PR TITLE
Extract substrate build to reusable workflow

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -70,52 +70,13 @@ jobs:
         with:
           name: vagrant-rubygem
           path: ./gem
-  build-launchers:
-    if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
-    needs: [info]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - name: Build launchers
-        run: make bin/launcher/linux
-      - name: Store Launchers
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-launchers
-          path: ./bin
-  # TODO: This is exactly the same substrate step as the one in build-debs.yml.
-  # It can use cached builds from that job and produce builds that job can use.
-  # Instead of duplicating the steps, it would be cleaner to have the
-  # build-substrate behavior factored out into its own set of jobs that both
-  # build-debs and build-appimage could depend on.
   build-substrate-64:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
-    needs: [info, build-launchers]
-    runs-on: ubuntu-latest
+    needs: [info]
     permissions:
       contents: write
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
-        with:
-          name: vagrant-launchers
-          path: ./bin
-      - name: Build Substrate 64-bit
-        run: sudo ./.ci/ubuntu-substrate 64 ./artifacts
-      - name: Cache Substrate 64-bit
-        run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
-        env:
-          CACHE_ID: ${{ needs.info.outputs.deb-64-substrate-id }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/build-deb-substrate64.yml
+    secrets: inherit
   build-package:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.appimage-package-exists != 'true' && !cancelled() && !failure() }}
     needs: [info, build-substrate-64]

--- a/.github/workflows/build-deb-substate64.yml
+++ b/.github/workflows/build-deb-substate64.yml
@@ -1,0 +1,63 @@
+on:
+  workflow_call:
+    outputs:
+      substrate-id:
+        description: Cache identifier for deb 64 substrate
+        value: ${{ jobs.info.outputs.deb-64-substrate-id }}
+
+# Since this workflow is used in multiple locations
+# only allow one of them to run at a time to prevent
+# them attempting to run on top of eachother
+concurrency: ${{ github.workflow }}
+
+jobs:
+  info:
+    if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      deb-64-substrate-id: ${{ steps.inspect.outputs.deb-64-substrate-id }}
+      deb-64-substrate-exists: ${{ steps.inspect.outputs.deb-64-substrate-exists }}
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build launchers
+        run: make bin/launcher/linux-x86_64
+      - name: Store Launchers
+        uses: actions/upload-artifact@v3
+        with:
+          name: vagrant-launchers
+          path: ./bin
+      - name: Gather information
+        id: inspect
+        run: ./.ci/deb-build-information
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-substrate-64:
+    if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
+    needs: [info]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch Launchers
+        uses: actions/download-artifact@v3
+        with:
+          name: vagrant-launchers
+          path: ./bin
+      - name: Build Substrate 64-bit
+        run: sudo ./.ci/ubuntu-substrate 64 ./artifacts
+      - name: Cache Substrate 64-bit
+        run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
+        env:
+          CACHE_ID: ${{ needs.info.outputs.deb-64-substrate-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -108,27 +108,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.deb-32-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # The 64 bit substrate is also used by appimage so it was
+  # extracted to an isolated workflow to be shared
   build-substrate-64:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
     needs: [info]
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
-        with:
-          name: vagrant-launchers
-          path: ./bin
-      - name: Build Substrate 64-bit
-        run: sudo ./.ci/ubuntu-substrate 64 ./artifacts
-      - name: Cache Substrate 64-bit
-        run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
-        env:
-          CACHE_ID: ${{ needs.info.outputs.deb-64-substrate-id }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/build-deb-substrate64.yml
+    secrets: inherit
   build-install-32:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-32-install-exists != 'true' && !cancelled() && !failure() }}
     needs: [info, build-substrate-32]


### PR DESCRIPTION
The AppImage build utilizes the substrate built for `.deb` packages.
This extracts that process into an isolated workflow that both can use.

The concurrency added only allows one instance of the workflow to run at
a given time. This is because we can't access the `needs` context from
concurrency so cannot use the generated id on the build job which would
be ideal.
