### PR TITLE
Sign files in background jobs

### DIFF
--- a/.ci/auto-sign-zip
+++ b/.ci/auto-sign-zip
@@ -19,6 +19,9 @@ root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
 #       which allows it to properly load user plugins.
 macho_entitled_binary_names=( "ruby" )
 
+# Maximum number of background jobs to allow
+max_jobs="100"
+
 # Simple helper to check if binary at given path should
 # have entitlements applied
 function is_entitled() {
@@ -135,28 +138,73 @@ for file in "${entries[@]}"; do
     debug "ignoring path which does not require signing: %s" "${file}"
 done
 
+# Store job information
+jobs=()
+
 # Now that files are separated into lists, cycle
 # through them and sign the files
 info "Signing files..."
 # Windows signing
 for file in "${win_binaries[@]}"; do
+    background_jobs_limit "${max_jobs}"
     debug "signing windows binary: %s" "${file}"
-    "${signer}" "${file}" ||
+    "${signer}" "${file}" &
+    jobs+=( "${file}" "${!}" )
+done
+
+# Check that windows files were properly signed
+while [ "${#jobs[@]}" -gt "0" ]; do
+    file="${jobs[0]}"
+    pid="${jobs[1]}"
+    if ! wait "${pid}"; then
         failure "Could not sign Windows binary file (%s)" "${file}"
+    fi
+    unset 'jobs[0]'
+    unset 'jobs[1]'
+    # compact jobs array
+    jobs=( "${jobs[@]}" )
 done
 
 # Mach-O library signing
 for file in "${macho_libs[@]}"; do
+    background_jobs_limit "${max_jobs}"
     debug "signing mach-o library binary: %s" "${file}"
-    "${signer}" "${file}" ||
+    "${signer}" "${file}" &
+    jobs+=( "${file}" "${!}" )
+done
+
+# Check that Mach-O library files were properly signed
+while [ "${#jobs[@]}" -gt "0" ]; do
+    file="${jobs[0]}"
+    pid="${jobs[1]}"
+    if ! wait "${pid}"; then
         failure "Could not sign Mach-O library file (%s)" "${file}"
+    fi
+    unset 'jobs[0]'
+    unset 'jobs[1]'
+    # compact jobs array
+    jobs=( "${jobs[@]}" )
 done
 
 # Mach-O executable signing
 for file in "${macho_execs[@]}"; do
+    background_jobs_limit "${max_jobs}"
     debug "signing mach-o executable binary: %s" "${file}"
-    "${signer}" "${file}" -b "${file##*/}" ||
+    "${signer}" "${file}" -b "${file##*/}" &
+    jobs+=( "${file}" "${!}" )
+done
+
+# Check that Mach-O executable files were properly signed
+while [ "${#jobs[@]}" -gt "0" ]; do
+    file="${jobs[0]}"
+    pid="${jobs[1]}"
+    if ! wait "${pid}"; then
         failure "Could not sign Mach-O executable file (%s)" "${file}"
+    fi
+    unset 'jobs[0]'
+    unset 'jobs[1]'
+    # compact jobs array
+    jobs=( "${jobs[@]}" )
 done
 
 # Mach-O executable with entitlements signing
@@ -172,10 +220,25 @@ cat <<EOF >entitlements.plist
 </plist>
 EOF
 for file in "${macho_entitled_execs[@]}"; do
+    background_jobs_limit "${max_jobs}"
     debug "signing mach-o executable binary file with entitlements: %s" "${file}"
-    "${signer}" "${file}" -b "${file##*/}" -e ./entitlements.plist ||
-        failure "Could not sign Mach-O executable file with entitlements (%s)" "${file}"
+    "${signer}" "${file}" -b "${file##*/}" -e ./entitlements.plist &
+    jobs+=( "${file}" "${!}" )
 done
+
+# Check that Mach-O entitled executable files were properly signed
+while [ "${#jobs[@]}" -gt "0" ]; do
+    file="${jobs[0]}"
+    pid="${jobs[1]}"
+    if ! wait "${pid}"; then
+        failure "Could not sign Mach-O executable file with entitlements (%s)" "${file}"
+    fi
+    unset 'jobs[0]'
+    unset 'jobs[1]'
+    # compact jobs array
+    jobs=( "${jobs[@]}" )
+done
+
 # Remove the entitlements file
 rm -f ./entitlements.plist
 


### PR DESCRIPTION
Define a maximum number of background jobs to allow and background
signing requests to speed up the process.
