### PR TITLE
Update macOS SDK

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -80,7 +80,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install Ruby
-        run: sudo apt-get install -yq ruby
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq ruby
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Fetch Vagrant Artifacts

--- a/substrate/deps.sh
+++ b/substrate/deps.sh
@@ -8,8 +8,6 @@
 # a package manager and have more updates applied outside our
 # view. Update the date below to force a new substrate build
 # when no libraries need to be updated:
-#
-# FORCE REBUILD: 2022-08-11 16:52:43-07:00
 
 curl_version="7.87.0"
 libarchive_version="3.6.2"
@@ -31,3 +29,7 @@ zlib_version="1.2.13"
 
 # Only used for centos
 libxcrypt_version="4.4.18"
+
+# Only used for macOS
+macos_sdk_file="MacOSX10.9.sdk.tgz"
+macos_deployment_target="10.10"

--- a/substrate/deps.sh
+++ b/substrate/deps.sh
@@ -31,5 +31,7 @@ zlib_version="1.2.13"
 libxcrypt_version="4.4.18"
 
 # Only used for macOS
-macos_sdk_file="MacOSX10.9.sdk.tgz"
-macos_deployment_target="10.10"
+# NOTE: The 10.12 SDK was the earliest version of the
+#       SDK which could properly build all the dependencies
+macos_sdk_file="MacOSX10.12.sdk.tgz"
+macos_deployment_target="10.12"

--- a/substrate/deps.sh
+++ b/substrate/deps.sh
@@ -19,7 +19,7 @@ libiconv_version="1.17"
 # Need up update gcc version to use libssh2 1.9.0+
 libssh2_version="1.8.0"
 libxml2_version="2.10.3"
-libxslt_version="1.1.37"
+libxslt_version="1.1.38"
 libyaml_version="0.2.5"
 openssl_version="1.1.1s"
 readline_version="8.2"

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -299,11 +299,24 @@ if [[ "${target_os}" = "darwin" ]]; then
     else # By default we target x86_64
         info "   ** macOS build target architecture: x86_64"
 
-        # Defines the minimum version of macOS to target
-        # NOTE: Ruby depends on features only available starting with
-        #       10.13. Check if we can pull in the 10.9 sdk manually
-        #       and build with that.
-        macos_deployment_target="10.13"
+        if [ -n "${macos_sdk_file}" ]; then
+            info "   ** Custom SDK defined (%s), downloading..." "${macos_sdk_file}"
+            pushd "${cache_dir}" > /dev/null || exit
+            sdk_path="$(mktemp -d vagrant-substrate.XXXXX)" || exit
+            pushd "${sdk_path}" > /dev/null || exit
+            sdk_path="$(pwd)" || exit
+            curl -f -L -s -o sdk.tgz "${dep_cache}/${macos_sdk_file}" || exit
+            tar xf ./sdk.tgz || exit
+            popd > /dev/null || exit
+        fi
+
+        if [ -z "${macos_deployment_target}" ]; then
+            # Defines the minimum version of macOS to target
+            # NOTE: Ruby depends on features only available starting with
+            #       10.13. Check if we can pull in the 10.9 sdk manually
+            #       and build with that.
+            macos_deployment_target="10.13"
+        fi
         target_host="x86_64-apple-darwin"
 
         # Modifications required to configure scripts for cross building
@@ -336,7 +349,9 @@ if [[ "${target_os}" = "darwin" ]]; then
         export ARCHFLAGS="-arch x86_64"
     fi
 
-    sdk_path="$(xcrun --sdk macosx --show-sdk-path)" || exit
+    if [ -z "${sdk_path}" ]; then
+        sdk_path="$(xcrun --sdk macosx --show-sdk-path)" || exit
+    fi
 
     export MACOSX_DEPLOYMENT_TARGET="${macos_deployment_target}"
     export SDKROOT="${sdk_path}"

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -319,10 +319,9 @@ if [[ "${target_os}" = "darwin" ]]; then
         fi
 
         if [ -z "${macos_deployment_target}" ]; then
-            # Defines the minimum version of macOS to target
-            # NOTE: Ruby depends on features only available starting with
-            #       10.13. Check if we can pull in the 10.9 sdk manually
-            #       and build with that.
+            # Defines the minimum version of macOS to target when not
+            # already set. Defaults to 10.13 as this will build correctly
+            # on latest
             macos_deployment_target="10.13"
         fi
         target_host="x86_64-apple-darwin"

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -307,6 +307,14 @@ if [[ "${target_os}" = "darwin" ]]; then
             sdk_path="$(pwd)" || exit
             curl -f -L -s -o sdk.tgz "${dep_cache}/${macos_sdk_file}" || exit
             tar xf ./sdk.tgz || exit
+            files=( ./* )
+            for f in "${files[@]}"; do
+                if [ -d "${f}" ]; then
+                    pushd "${f}" || exit
+                    sdk_path="$(pwd)" || exit
+                    popd || exit
+                fi
+            done
             popd > /dev/null || exit
         fi
 


### PR DESCRIPTION
Build against the earliest SDK possible. For now that
looks to be the 10.12 SDK. A small bump for the
libxslt library is included as well.
