### PR TITLE
Update build artifacts generation strategy

### DIFF
--- a/.ci/fetch-vagrant-info
+++ b/.ci/fetch-vagrant-info
@@ -10,34 +10,17 @@ while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
 root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
 
 . "${root}/.ci/load-ci.sh"
-pushd "${root}"
 
-if [ "${1}" == "--tag-required" ] && [ -z "${tag}" ]; then
-    failure "Tag is required but workflow was not triggered by a tag"
+if [ "${#}" -ne 1 ]; then
+    printf "Usage: %s ARTIFACT_DIR\n" "${0}" >&2
+    exit 1
+fi
+ARTIFACT_DIR="${1}"
+if [ ! -d "${ARTIFACT_DIR}" ]; then
+    failure "Invalid path provided for artifact directory (%s)" "${ARTIFACT_DIR}"
 fi
 
-# If both names are empty default to main
-# for draft release
-if [ -z "${VAGRANT_DRAFT_NAME}" ] && [ -z "${VAGRANT_RELEASE_NAME}" ]; then
-    debug "no release name provided via github event, defaulting to main draft"
-    VAGRANT_DRAFT_NAME="main"
-fi
-
-mkdir -p ./vagrant-artifacts ||
-    failure "Could not create directory for Vagrant artifacts"
-
-pushd ./vagrant-artifacts
-if [ -n "${VAGRANT_RELEASE_NAME}" ]; then
-    debug "fetching vagrant rubygem from vagrant release %s" "${VAGRANT_RELEASE_NAME}"
-    github_release_assets "vagrant" "${VAGRANT_RELEASE_NAME}" ".gem"
-    github_release_assets "vagrant" "${VAGRANT_RELEASE_NAME}" ".txt"
-fi
-
-if [ -n "${VAGRANT_DRAFT_NAME}" ]; then
-    debug "fetching vagrant rubygem from vagrant draft %s" "${VAGRANT_DRAFT_NAME}"
-    github_draft_release_assets "vagrant" "${VAGRANT_DRAFT_NAME}" ".gem"
-    github_draft_release_assets "vagrant" "${VAGRANT_DRAFT_NAME}" ".txt"
-fi
+pushd "${ARTIFACT_DIR}"
 
 g_files=( ./vagrant*.gem )
 gem_file="${g_files[0]}"
@@ -54,13 +37,6 @@ sha_info="$(sha1sum "${gem_file}")" ||
     failure "Unable to generate shasum for Vagrant RubyGem"
 vagrant_sha="${sha_info%% *}"
 
-if [ ! -f "./commit-id.txt" ]; then
-    failure "Expected commit ID file missing from artifacts (./commit-id.txt)"
-fi
-commit_id="$( <./commit-id.txt )"
-
 # Write the outputs
 printf "vagrant-version=%s\n" "${vagrant_version}" >> "${GITHUB_OUTPUT}"
 printf "vagrant-shasum=%s\n" "${vagrant_sha}" >> "${GITHUB_OUTPUT}"
-printf "vagrant-commit-id=%s\n" "${commit_id}" >> "${GITHUB_OUTPUT}"
-printf "vagrant-tag=%s\n" "${tag}" >> "${GITHUB_OUTPUT}"

--- a/.ci/fetch-vagrant-source-info
+++ b/.ci/fetch-vagrant-source-info
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Output to stdout if we aren't on a runner
+if [ -z "${GITHUB_OUTPUT}" ]; then
+    GITHUB_OUTPUT="/dev/stdout"
+fi
+
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/.ci/load-ci.sh"
+
+if [ "${#}" -ne 1 ]; then
+    printf "Usage: %s VAGRANT_SOURCE_DIR\n" "${0}" >&2
+    exit 1
+fi
+SOURCE_DIR="${1}"
+if [ ! -d "${SOURCE_DIR}" ]; then
+    failure "Invalid path provided for vagrant source directory (%s)" "${SOURCE_DIR}"
+fi
+
+pushd "${SOURCE_DIR}"
+
+# Get the commit ID for the vagrant source in use
+commit_id="$(git rev-parse HEAD)" ||
+    failure "Failed to get commit ID for Vagrant repository"
+
+printf "vagrant-commit-id=%s\n" "${commit_id}" >> "${GITHUB_OUTPUT}"
+
+# Check if the initial build artifacts have already been cached
+cache_id="vagrant-${commit_id}"
+printf "vagrant-cache-id=%s\n" "${cache_id}" >> "${GITHUB_OUTPUT}"
+
+if github_draft_release_exists "${repo_name}" "${cache_id}"; then
+    printf "vagrant-cache-exists=true\n" >> "${GITHUB_OUTPUT}"
+fi

--- a/.ci/publish-nightlies
+++ b/.ci/publish-nightlies
@@ -12,6 +12,11 @@ if [ -z "${GITHUB_OUTPUT}" ]; then
     GITHUB_OUTPUT="/dev/stdout"
 fi
 
+if [ "${#}" -ne 3 ]; then
+    printf "Usage: %s RELEASE_NAME COMMITISH ARTIFACT_DIR\n" "${0}" >&2
+    exit 1
+fi
+
 release_name="${1}"
 commitish="${2}"
 pkg_dir="${3}"
@@ -31,6 +36,11 @@ pushd "${pkg_dir}"
 pkg_dir="$(pwd)" ||
     failure "Invalid package directory provided (%s)" "${pkg_dir}"
 popd
+
+if github_release_exists "vagrant" "${release_name}"; then
+    warn "Vagrant release (%s) already exists, removing..." "${release_name}"
+    github_delete_release "${release_name}" "vagrant"
+fi
 
 # Create the release
 debug "creating nightly vagrant release - %s" "${release_name}"

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,22 +1,34 @@
 on:
   workflow_call:
     inputs:
-      vagrant_draft_name:
-        description: Name of the Vagrant repository draft release containing gem for build
-        required: false
+      vagrant-artifacts-name:
+        description: Name of upload containing Vagrant build artifacts
+        required: true
         type: string
-      vagrant_release_name:
-        description: Name of the Vagrant repository release containing gem for build
-        required: false
+      vagrant-artifacts-path:
+        description: Path used for Vagrant build artifacts
+        required: true
+        type: string
+      vagrant-gem-name:
+        description: Name of upload containing the Vagrant RubyGem
+        required: true
+        type: string
+      vagrant-gem-path:
+        description: Path used for the Vagrant RubyGem (directory)
+        required: true
+        type: string
+      vagrant-version:
+        description: Version of Vagrant being built
+        required: true
+        type: string
+      vagrant-shasum:
+        description: The shasum of the Vagrant RubyGem
+        required: true
         type: string
     outputs:
       appimage-package-id:
         description: Cache identifier for appimage packages
         value: ${{ jobs.info.outputs.appimage-package-id }}
-      vagrant-version:
-        description: Version of Vagrant package built
-        value: ${{ jobs.info.outputs.vagrant-version }}
-
 jobs:
   info:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
@@ -25,8 +37,6 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      vagrant-version: ${{ steps.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-artifacts.outputs.vagrant-shasum }}
       deb-64-substrate-id: ${{ steps.inspect.outputs.deb-64-substrate-id }}
       deb-64-substrate-exists: ${{ steps.inspect.outputs.deb-64-substrate-exists }}
       appimage-package-id: ${{ steps.inspect.outputs.appimage-package-id }}
@@ -48,37 +58,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant RubyGem
-        id: vagrant-artifacts
-        run: ./.ci/fetch-vagrant-files
-        env:
-          VAGRANT_DRAFT_NAME: ${{ inputs.draft_name }}
-          VAGRANT_RELEASE_NAME: ${{ inputs.release_name }}
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Gather information
         id: inspect
         run: ./.ci/deb-build-information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_SHASUM: ${{ steps.vagrant-gem.outputs.vagrant-shasum }}
-      - name: Store Vagrant RubyGem
-        if: ${{ steps.inspect.outputs.appimage-package-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-rubygem-appimage
-          path: ./gem
+          VAGRANT_SHASUM: ${{ inputs.vagrant-shasum }}
   build-substrate-64:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
     needs: [info]
     permissions:
       contents: write
     uses: ./.github/workflows/build-deb-substrate64.yml
+    with:
+      deb-64-substrate-id: ${{ needs.info.outputs.deb-64-substrate-id }}
     secrets: inherit
   build-package:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.appimage-package-exists != 'true' && !cancelled() && !failure() }}
@@ -94,13 +87,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.deb-64-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch RubyGem
+      - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-appimage
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Package appimage
-        run: sudo ./.ci/build-appimage-in-chroot ./gem ./substrates ./pkgs
+        run: sudo ./.ci/build-appimage-in-chroot "${VAGRANT_GEM_PATH}" ./substrates ./pkgs
+        env:
+          VAGRANT_GEM_PATH: ${{ inputs.vagrant-gem-path }}
       - name: Cache Vagrant appimage
         run: ./.ci/create-cache "${CACHE_ID}" ./pkgs
         env:

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -1,25 +1,34 @@
 on:
   workflow_call:
     inputs:
-      vagrant_draft_name:
-        description: Name of the Vagrant repository draft release containing gem for build
-        required: false
+      vagrant-artifacts-name:
+        description: Name of upload containing Vagrant build artifacts
+        required: true
         type: string
-      vagrant_release_name:
-        description: Name of the Vagrant repository release containing gem for build
-        required: false
+      vagrant-artifacts-path:
+        description: Path used for Vagrant build artifacts
+        required: true
+        type: string
+      vagrant-gem-name:
+        description: Name of upload containing the Vagrant RubyGem
+        required: true
+        type: string
+      vagrant-gem-path:
+        description: Path used for the Vagrant RubyGem (directory)
+        required: true
+        type: string
+      vagrant-version:
+        description: Version of Vagrant being built
+        required: true
+        type: string
+      vagrant-shasum:
+        description: The shasum of the Vagrant RubyGem
+        required: true
         type: string
     outputs:
       arch-package-id:
         description: Cache identifier for arch linux package
         value: ${{ jobs.info.outputs.arch-package-id }}
-      vagrant-version:
-        description: Version of Vagrant package built
-        value: ${{ jobs.info.outputs.vagrant-version }}
-      vagrant-commit-id:
-        description: Commit ID on the Vagrant repository associated to this build
-        value: ${{ jobs.info.outputs.vagrant-commit-id }}
-
 jobs:
   info:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
@@ -28,9 +37,6 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      vagrant-version: ${{ steps.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-artifacts.outputs.vagrant-shasum }}
-      vagrant-commit-id: ${{ steps.vagrant-artifacts.vagrant-commit-id }}
       arch-substrate-id: ${{ steps.inspect.outputs.arch-substrate-id }}
       arch-substrate-exists: ${{ steps.inspect.outputs.arch-substrate-exists }}
       arch-install-id: ${{ steps.inspect.outputs.arch-install-id }}
@@ -54,51 +60,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Go
-        if: ${{ steps.inspect.outputs.arch-substrate-exists != 'true' }}
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant Artifacts
-        id: vagrant-artifacts
-        run: ./.ci/fetch-vagrant-files
-        env:
-          VAGRANT_DRAFT_NAME: ${{ inputs.draft_name }}
-          VAGRANT_RELEASE_NAME: ${{ inputs.release_name }}
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Gather information
         id: inspect
         run: ./.ci/arch-build-information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_SHASUM: ${{ steps.vagrant-gem.outputs.vagrant-shasum }}
-      - name: Store Vagrant RubyGem
-        if: ${{ steps.inspect.outputs.arch-install-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-rubygem-arch
-          path: ./gem
-      - name: Store Vagrant Artifacts
-        if: ${{ steps.inspect.outputs.arch-package-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-artifacts-arch
-          path: ./vagrant-artifacts
-      - name: Build launchers
-        if: ${{ steps.inspect.outputs.arch-substrate-exists != 'true' }}
-        run: make bin/launcher/linux-x86_64
-      - name: Store Launchers
-        if: ${{ steps.inspect.outputs.arch-substrate-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-launchers-arch
-          path: ./bin
+          VAGRANT_SHASUM: ${{ inputs.vagrant-shasum }}
   build-substrate:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.arch-substrate-exists != 'true' }}
     needs: [info]
@@ -108,11 +75,12 @@ jobs:
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          name: vagrant-launchers-arch
-          path: ./bin
+          go-version-file: go.mod
+      - name: Build Launchers
+        run: make bin/launcher/linux-x86_64
       - name: Enable LXD
         run: sudo usermod -a -G lxd "${USER}"
       - name: Build Substrate
@@ -136,15 +104,17 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.arch-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch vagrant gem
+      - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-arch
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Enable LXD
         run: sudo usermod -a -G lxd "${USER}"
       - name: Install Vagrant
-        run: sg lxd "./.ci/arch-install ./gem ./substrates ./artifacts"
+        run: sg lxd "./.ci/arch-install '${VAGRANT_GEM_PATH}' ./substrates ./artifacts"
+        env:
+          VAGRANT_GEM_PATH: ${{ inputs.vagrant-gem-path }}
       - name: Cache Install
         run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
         env:
@@ -164,17 +134,18 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.arch-install-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch Artifacts
+      - name: Fetch Vagrant Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-artifacts-arch
-          path: ./vagrant-artifacts
+          name: ${{ inputs.vagrant-artifacts-name }}
+          path: ${{ inputs.vagrant-artifacts-path }}
       - name: Enable LXD
         run: sudo usermod -a -G lxd "${USER}"
       - name: Build package
-        run: sg lxd "./.ci/arch-package ./artifacts/vagrant-installed.zip ./vagrant-artifacts/vagrant-go_linux_amd64 ./pkgs ${VERSION}"
+        run: sg lxd "./.ci/arch-package ./artifacts/vagrant-installed.zip '${VAGRANT_ARTIFACTS}/vagrant-go_linux_amd64' ./pkgs ${VERSION}"
         env:
-          VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VAGRANT_ARTIFACTS: ${{ inputs.vagrant-artifacts-path }}
+          VERSION: ${{ inputs.vagrant-version }}
       - name: Cache Package
         run: ./.ci/create-cache "${CACHE_ID}" ./pkgs
         env:

--- a/.github/workflows/build-deb-substrate64.yml
+++ b/.github/workflows/build-deb-substrate64.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    inputs:
+      deb-64-substrate-id:
+        description: Cache identifier for substrate artifact
+        required: true
+        type: string
     outputs:
       substrate-id:
         description: Cache identifier for deb 64 substrate
@@ -11,53 +16,25 @@ on:
 concurrency: ${{ github.workflow }}
 
 jobs:
-  info:
-    if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
+  build-substrate-64:
+    name: Build Debian 64 Substrate
+    if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      deb-64-substrate-id: ${{ steps.inspect.outputs.deb-64-substrate-id }}
-      deb-64-substrate-exists: ${{ steps.inspect.outputs.deb-64-substrate-exists }}
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - name: Build launchers
+      - name: Build Launchers
         run: make bin/launcher/linux-x86_64
-      - name: Store Launchers
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-launchers-debsub
-          path: ./bin
-      - name: Gather information
-        id: inspect
-        run: ./.ci/deb-build-information
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-substrate-64:
-    if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-64-substrate-exists != 'true' }}
-    needs: [info]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
-        with:
-          name: vagrant-launchers-debsub
-          path: ./bin
       - name: Build Substrate 64-bit
         run: sudo ./.ci/ubuntu-substrate 64 ./artifacts
       - name: Cache Substrate 64-bit
         run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
         env:
-          CACHE_ID: ${{ needs.info.outputs.deb-64-substrate-id }}
+          CACHE_ID: ${{ inputs.deb-64-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -1,24 +1,34 @@
 on:
   workflow_call:
     inputs:
-      vagrant_draft_name:
-        description: Name of the Vagrant repository draft release containing gem for build
-        required: false
+      vagrant-artifacts-name:
+        description: Name of upload containing Vagrant build artifacts
+        required: true
         type: string
-      vagrant_release_name:
-        description: Name of the Vagrant repository release containing gem for build
-        required: false
+      vagrant-artifacts-path:
+        description: Path used for Vagrant build artifacts
+        required: true
+        type: string
+      vagrant-gem-name:
+        description: Name of upload containing the Vagrant RubyGem
+        required: true
+        type: string
+      vagrant-gem-path:
+        description: Path used for the Vagrant RubyGem (directory)
+        required: true
+        type: string
+      vagrant-version:
+        description: Version of Vagrant being built
+        required: true
+        type: string
+      vagrant-shasum:
+        description: The shasum of the Vagrant RubyGem
+        required: true
         type: string
     outputs:
       deb-packages-id:
         description: Cache identifier for deb packages
         value: ${{ jobs.info.outputs.deb-packages-id }}
-      vagrant-version:
-        description: Version of Vagrant package built
-        value: ${{ jobs.info.outputs.vagrant-version }}
-      vagrant-commit-id:
-        description: Commit ID on the Vagrant repository associated to this build
-        value: ${{ jobs.info.outputs.vagrant-commit-id }}
 jobs:
   info:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
@@ -27,9 +37,6 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      vagrant-version: ${{ steps.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-artifacts.outputs.vagrant-shasum }}
-      vagrant-commit-id: ${{ steps.vagrant-artifacts.vagrant-commit-id }}
       deb-32-substrate-id: ${{ steps.inspect.outputs.deb-32-substrate-id }}
       deb-32-substrate-exists: ${{ steps.inspect.outputs.deb-32-substrate-exists }}
       deb-32-install-id: ${{ steps.inspect.outputs.deb-32-install-id }}
@@ -57,51 +64,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Go
-        if: ${{ steps.inspect.outputs.deb-32-substrate-exists != 'true' ||  steps.inspect.outputs.deb-64-substrate-exists != 'true' }}
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant Artifacts
-        id: vagrant-artifacts
-        run: ./.ci/fetch-vagrant-files
-        env:
-          VAGRANT_DRAFT_NAME: ${{ inputs.draft_name }}
-          VAGRANT_RELEASE_NAME: ${{ inputs.release_name }}
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Gather information
         id: inspect
         run: ./.ci/deb-build-information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_SHASUM: ${{ steps.vagrant-gem.outputs.vagrant-shasum }}
-      - name: Store Vagrant RubyGem
-        if: ${{ steps.inspect.outputs.deb-32-install-exists != 'true' ||  steps.inspect.outputs.deb-64-install-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-rubygem-debs
-          path: ./gem
-      - name: Store Vagrant Artifacts
-        if: ${{ steps.inspect.outputs.deb-packages-exist != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-artifacts-debs
-          path: ./vagrant-artifacts
-      - name: Build launchers
-        if: ${{ steps.inspect.outputs.deb-32-substrate-exists != 'true' ||  steps.inspect.outputs.deb-64-substrate-exists != 'true' }}
-        run: make bin/launcher/linux
-      - name: Store Launchers
-        if: ${{ steps.inspect.outputs.deb-32-substrate-exists != 'true' ||  steps.inspect.outputs.deb-64-substrate-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-launchers-debs
-          path: ./bin
+          VAGRANT_SHASUM: ${{ inputs.vagrant-shasum }}
   build-substrate-32:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-32-substrate-exists != 'true' }}
     needs: [info]
@@ -111,11 +79,12 @@ jobs:
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          name: vagrant-launchers-debs
-          path: ./bin
+          go-version-file: go.mod
+      - name: Build Launchers
+        run: make bin/launcher/linux-386
       - name: Build Substrate 32-bit
         run: sudo ./.ci/ubuntu-substrate 32 ./artifacts
       - name: Cache Substrate 32-bit
@@ -131,6 +100,8 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/build-deb-substrate64.yml
+    with:
+      deb-64-substrate-id: ${{ needs.info.outputs.deb-64-substrate-id }}
     secrets: inherit
   build-install-32:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.deb-32-install-exists != 'true' && !cancelled() && !failure() }}
@@ -146,13 +117,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.deb-32-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch RubyGem
+      - name: Fetch Vagrant Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-debs
-          path: ./gem
+          name: ${{ inputs.vagrant-artifacts-name }}
+          path: ${{ inputs.vagrant-artifacts-path }}
       - name: Run install
-        run: sudo ./.ci/ubuntu-install ./gem ./substrates ./artifacts
+        run: sudo ./.ci/ubuntu-install "${ARTIFACTS_PATH}" ./substrates ./artifacts
+        env:
+          ARTIFACTS_PATH: ${{ inputs.vagrant-artifacts-path }}
       - name: Cache Install 32-bit
         run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
         env:
@@ -172,13 +145,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.deb-64-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch RubyGem
+      - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-debs
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Run install
-        run: sudo ./.ci/ubuntu-install ./gem ./substrates ./artifacts
+        run: sudo ./.ci/ubuntu-install "${VAGRANT_GEM_PATH}" ./substrates ./artifacts
+        env:
+          VAGRANT_GEM_PATH: ${{ inputs.vagrant-gem-path }}
       - name: Cache Install 64-bit
         run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
         env:
@@ -209,19 +184,21 @@ jobs:
           ruby-version: 3.1
       - name: Install fpm
         run: gem install --no-document fpm
-      - name: Fetch Artifacts
+      - name: Fetch Vagrant Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-artifacts-debs
-          path: ./vagrant-artifacts
+          name: ${{ inputs.vagrant-artifacts-name }}
+          path: ${{ inputs.vagrant-artifacts-path }}
       - name: Package 32-bit
-        run: ./package/build-deb ./artifacts/installed_ubuntu_386.zip ./vagrant-artifacts/vagrant-go_linux_386 ./pkgs "${VERSION}"
+        run: ./package/build-deb ./artifacts/installed_ubuntu_386.zip "${ARTIFACTS_PATH}/vagrant-go_linux_386" ./pkgs "${VERSION}"
         env:
-          VERSION: ${{ needs.info.outputs.vagrant-version }}
+          ARTIFACTS_PATH: ${{ inputs.vagrant-artifacts-path }}
+          VERSION: ${{ inputs.vagrant-version }}
       - name: Package 64-bit
-        run: ./package/build-deb ./artifacts/installed_ubuntu_x86_64.zip ./vagrant-artifacts/vagrant-go_linux_amd64 ./pkgs "${VERSION}"
+        run: ./package/build-deb ./artifacts/installed_ubuntu_x86_64.zip "${ARTIFACTS_PATH}/vagrant-go_linux_amd64" ./pkgs "${VERSION}"
         env:
-          VERSION: ${{ needs.info.outputs.vagrant-version }}
+          ARTIFACTS_PATH: ${{ inputs.vagrant-artifacts-path }}
+          VERSION: ${{ inputs.vagrant-version }}
       - name: Cache Vagrant debs
         run: ./.ci/create-cache "${CACHE_ID}" ./pkgs
         env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,25 +1,34 @@
 on:
   workflow_call:
     inputs:
-      vagrant_draft_name:
-        description: Name of the Vagrant repository draft release containing gem for build
-        required: false
+      vagrant-artifacts-name:
+        description: Name of upload containing Vagrant build artifacts
+        required: true
         type: string
-      vagrant_release_name:
-        description: Name of the Vagrant repository release containing gem for build
-        required: false
+      vagrant-artifacts-path:
+        description: Path used for Vagrant build artifacts
+        required: true
+        type: string
+      vagrant-gem-name:
+        description: Name of upload containing the Vagrant RubyGem
+        required: true
+        type: string
+      vagrant-gem-path:
+        description: Path used for the Vagrant RubyGem (directory)
+        required: true
+        type: string
+      vagrant-version:
+        description: Version of Vagrant being built
+        required: true
+        type: string
+      vagrant-shasum:
+        description: The shasum of the Vagrant RubyGem
+        required: true
         type: string
     outputs:
       dmg-cache-id:
         description: Cache identifier for macOS universal dmg
         value: ${{ jobs.info.outputs.dmg-signed-id }}
-      vagrant-version:
-        description: Version of Vagrant package built
-        value: ${{ jobs.info.outputs.vagrant-version }}
-      vagrant-commit-id:
-        description: Commit ID on the Vagrant repository associated to this build
-        value: ${{ jobs.info.outputs.vagrant-commit-id }}
-
 jobs:
   info:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
@@ -28,9 +37,6 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      vagrant-version: ${{ steps.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-artifacts.outputs.vagrant-shasum }}
-      vagrant-commit-id: ${{ steps.vagrant-artifacts.vagrant-commit-id }}
       substrate-arm-unsigned-id: ${{ steps.inspect.outputs.substrate-arm-unsigned-id }}
       substrate-arm-unsigned-exists: ${{ steps.inspect.outputs.substrate-arm-unsigned-exists }}
       substrate-arm-signed-id: ${{ steps.inspect.outputs.substrate-arm-signed-id }}
@@ -74,51 +80,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Go
-        if: ${{ steps.inspect.outputs.substrate-arm-unsigned-exists != 'true' || steps.inspect.outputs.substrate-x86-unsigned-exists != 'true' }}
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant Artifacts
-        id: vagrant-artifacts
-        run: ./.ci/fetch-vagrant-files
-        env:
-          VAGRANT_DRAFT_NAME: ${{ inputs.draft_name }}
-          VAGRANT_RELEASE_NAME: ${{ inputs.release_name }}
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Gather information
         id: inspect
         run: ./.ci/macos-build-information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_SHASUM: ${{ steps.vagrant-gem.outputs.vagrant-shasum }}
-      - name: Store Vagrant RubyGem
-        uses: actions/upload-artifact@v3
-        if: ${{ steps.inspect.outputs.gems-unsigned-exists != 'true' }}
-        with:
-          name: vagrant-rubygem-darwin
-          path: ./gem
-      - name: Store Vagrant Artifacts
-        if: ${{ steps.inspect.outputs.core-pkg-unsigned-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-artifacts-darwin
-          path: ./vagrant-artifacts
-      - name: Build launchers
-        if: ${{ steps.inspect.outputs.substrate-arm-unsigned-exists != 'true' || steps.inspect.outputs.substrate-x86-unsigned-exists != 'true' }}
-        run: make bin/launcher/darwin
-      - name: Store Launchers
-        if: ${{ steps.inspect.outputs.substrate-arm-unsigned-exists != 'true' || steps.inspect.outputs.substrate-x86-unsigned-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-launchers-darwin
-          path: ./bin
+          VAGRANT_SHASUM: ${{ inputs.vagrant-shasum }}
   build-arm-substrate:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.substrate-arm-unsigned-exists != 'true' }}
     runs-on: macos-latest
@@ -138,11 +105,12 @@ jobs:
           sudo chown "${username}" /opt/vagrant || exit
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          name: vagrant-launchers-darwin
-          path: ./bin
+          go-version-file: go.mod
+      - name: Build Launcher
+        run: make bin/launcher/darwin-arm64
       - name: Build ARM substrate
         run: ./substrate/run.sh ./artifacts
         env:
@@ -171,11 +139,12 @@ jobs:
           sudo chown "${username}" /opt/vagrant || exit
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          name: vagrant-launchers-darwin
-          path: ./bin
+          go-version-file: go.mod
+      - name: Build Launcher
+        run: make bin/launcher/darwin-arm64
       - name: Build x86 substrate
         run: ./substrate/run.sh ./artifacts
         env:
@@ -254,13 +223,15 @@ jobs:
             kv/data/github/hashicorp/vagrant-builders signore_macos_binary_signer;
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Artifacts
+      - name: Fetch Vagrant Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-artifacts-darwin
-          path: ./vagrant-artifacts
+          name: ${{ inputs.vagrant-artifacts-name }}
+          path: ${{ inputs.vagrant-artifacts-path }}
       - name: Relocate Vagrant Go Binary
-        run: mkdir ./vagrant-go-signed && mv ./vagrant-artifacts/vagrant-go_darwin_amd64 ./vagrant-go-signed/vagrant-go
+        run: mkdir ./vagrant-go-signed && mv "${VAGRANT_ARTIFACTS}/vagrant-go_darwin_amd64" ./vagrant-go-signed/vagrant-go
+        env:
+          VAGRANT_ARTIFACTS: ${{ inputs.vagrant-artifacts-path }}
       - name: Sign Vagrant Go Binary
         run: ./.ci/sign-file -b vagrant-go ./vagrant-go-signed/vagrant-go
         env:
@@ -361,13 +332,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CACHE_NAME: ${{ needs.info.outputs.substrate-universal-id }}
-      - name: Fetch vagrant gem
+      - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-darwin
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Install Vagrant
-        run: ./package/darwin/generate_package_contents ./universal-substrate/substrate_darwin_universal.zip ./gem/vagrant.gem
+        run: ./package/darwin/generate_package_contents ./universal-substrate/substrate_darwin_universal.zip "${VAGRANT_GEM_PATH}/vagrant.gem"
+        env:
+          VAGRANT_GEM_PATH: ${{ inputs.vagrant-gem-path }}
       - name: Store Vagrant install
         run: ./.ci/create-cache "${CACHE_NAME}" ./vagrant-package-contents.zip
         env:
@@ -446,7 +419,7 @@ jobs:
       - name: Build core package
         run: ./package/darwin/build_core_pkg ./artifacts/substrate_darwin_universal.zip ./artifacts/vagrant-package-contents.zip ./vagrant-go-signed/vagrant-go "${VAGRANT_VERSION}"
         env:
-          VAGRANT_VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ inputs.vagrant-version }}
       - name: Store core package
         run: ./.ci/create-cache "${CACHE_NAME}" ./core.pkg
         env:
@@ -580,7 +553,7 @@ jobs:
       - name: Build installer DMG
         run: ./package/darwin/build_vagrant_dmg ./artifacts/Vagrant.pkg "${VERSION}"
         env:
-          VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VERSION: ${{ inputs.vagrant-version }}
       - name: Store DMG
         run: ./.ci/create-cache "${CACHE_NAME}" ./*.dmg
         env:

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -1,25 +1,34 @@
 on:
   workflow_call:
     inputs:
-      vagrant_draft_name:
-        description: Name of the Vagrant repository draft release containing gem for build
-        required: false
+      vagrant-artifacts-name:
+        description: Name of upload containing Vagrant build artifacts
+        required: true
         type: string
-      vagrant_release_name:
-        description: Name of the Vagrant repository release containing gem for build
-        required: false
+      vagrant-artifacts-path:
+        description: Path used for Vagrant build artifacts
+        required: true
+        type: string
+      vagrant-gem-name:
+        description: Name of upload containing the Vagrant RubyGem
+        required: true
+        type: string
+      vagrant-gem-path:
+        description: Path used for the Vagrant RubyGem (directory)
+        required: true
+        type: string
+      vagrant-version:
+        description: Version of Vagrant being built
+        required: true
+        type: string
+      vagrant-shasum:
+        description: The shasum of the Vagrant RubyGem
+        required: true
         type: string
     outputs:
       rpm-packages-id:
         description: Cache identifier for rpm packages
         value: ${{ jobs.info.outputs.rpm-packages-id }}
-      vagrant-version:
-        description: Version of Vagrant package built
-        value: ${{ jobs.info.outputs.vagrant-version }}
-      vagrant-commit-id:
-        description: Commit ID on the Vagrant repository associated to this build
-        value: ${{ jobs.info.outputs.vagrant-commit-id }}
-
 jobs:
   info:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' }}
@@ -28,9 +37,6 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      vagrant-version: ${{ steps.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-artifacts.outputs.vagrant-shasum }}
-      vagrant-commit-id: ${{ steps.vagrant-artifacts.vagrant-commit-id }}
       rpm-32-substrate-id: ${{ steps.inspect.outputs.rpm-32-substrate-id }}
       rpm-32-substrate-exists: ${{ steps.inspect.outputs.rpm-32-substrate-exists }}
       rpm-32-install-id: ${{ steps.inspect.outputs.rpm-32-install-id }}
@@ -58,51 +64,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        if: ${{ steps.inspect.outputs.rpm-32-install-exists != 'true' || steps.inspect.outputs.rpm-64-install-exists != 'true' }}
-        with:
-          go-version-file: go.mod
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant Artifacts
-        id: vagrant-artifacts
-        run: ./.ci/fetch-vagrant-files
-        env:
-          VAGRANT_DRAFT_NAME: ${{ inputs.draft_name }}
-          VAGRANT_RELEASE_NAME: ${{ inputs.release_name }}
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Gather information
         id: inspect
         run: ./.ci/rpm-build-information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_SHASUM: ${{ steps.vagrant-gem.outputs.vagrant-shasum }}
-      - name: Store Vagrant RubyGem
-        if: ${{ steps.inspect.outputs.rpm-32-install-exists != 'true' || steps.inspect.outputs.rpm-64-install-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-rubygem-rpm
-          path: ./gem
-      - name: Store Vagrant Artifacts
-        if: ${{ steps.inspect.outputs.rpm-packages-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-artifacts-rpms
-          path: ./vagrant-artifacts
-      - name: Build launchers
-        if: ${{ steps.inspect.outputs.rpm-32-substrate-exists != 'true' || steps.inspect.outputs.rpm-64-substrate-exists != 'true' }}
-        run: make bin/launcher/linux
-      - name: Store Launchers
-        if: ${{ steps.inspect.outputs.rpm-32-substrate-exists != 'true' || steps.inspect.outputs.rpm-64-substrate-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-launchers-rpm
-          path: ./bin
+          VAGRANT_SHASUM: ${{ inputs.vagrant-shasum }}
   build-substrate-32:
     if: ${{ github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.rpm-32-substrate-exists != 'true' }}
     needs: [info]
@@ -112,11 +79,12 @@ jobs:
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          name: vagrant-launchers-rpm
-          path: ./bin
+          go-version-file: go.mod
+      - name: Build Launchers
+        run: make bin/launcher/linux-386
       - name: Build Substrate 32-bit
         run: sudo ./.ci/centos-substrate 32 ./artifacts
       - name: Cache Substrate 32-bit
@@ -133,11 +101,12 @@ jobs:
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Launchers
-        uses: actions/download-artifact@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          name: vagrant-launchers-rpm
-          path: ./bin
+          go-version-file: go.mod
+      - name: Build Launchers
+        run: make bin/launcher/linux-x86_64
       - name: Build Substrate 64-bit
         run: sudo ./.ci/centos-substrate 64 ./artifacts
       - name: Cache Substrate 64-bit
@@ -159,13 +128,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.rpm-32-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch RubyGem
+      - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-rpm
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Run install
-        run: sudo ./.ci/centos-install ./gem ./substrates ./artifacts
+        run: sudo ./.ci/centos-install "${VAGRANT_GEM_PATH}" ./substrates ./artifacts
+        env:
+          VAGRANT_GEM_PATH: ${{ inputs.vagrant-gem-path }}
       - name: Cache Install 32-bit
         run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
         env:
@@ -185,13 +156,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.rpm-64-substrate-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fetch RubyGem
+      - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-rpm
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Run install
-        run: sudo ./.ci/centos-install ./gem ./substrates ./artifacts
+        run: sudo ./.ci/centos-install "${VAGRANT_GEM_PATH}" ./substrates ./artifacts
+        env:
+          VAGRANT_GEM_PATH: ${{ inputs.vagrant-gem-path }}
       - name: Cache Install 64-bit
         run: ./.ci/create-cache "${CACHE_ID}" ./artifacts
         env:
@@ -222,19 +195,21 @@ jobs:
           ruby-version: 3.1
       - name: Install fpm
         run: gem install --no-document fpm
-      - name: Fetch Artifacts
+      - name: Fetch Vagrant Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-artifacts-rpms
-          path: ./vagrant-artifacts
+          name: ${{ inputs.vagrant-artifacts-name }}
+          path: ${{ inputs.vagrant-artifacts-path }}
       - name: Package 32-bit
-        run: ./package/build-rpm ./artifacts/installed_centos_386.zip ./vagrant-artifacts/vagrant-go_linux_386 ./pkgs "${VERSION}"
+        run: ./package/build-rpm ./artifacts/installed_centos_386.zip "${VAGRANT_ARTIFACTS}/vagrant-go_linux_386" ./pkgs "${VERSION}"
         env:
-          VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VAGRANT_ARTIFACTS: ${{ inputs.vagrant-artifacts-path }}
+          VERSION: ${{ inputs.vagrant-version }}
       - name: Package 64-bit
-        run: ./package/build-rpm ./artifacts/installed_centos_x86_64.zip ./vagrant-artifacts/vagrant-go_linux_amd64 ./pkgs "${VERSION}"
+        run: ./package/build-rpm ./artifacts/installed_centos_x86_64.zip "${VAGRANT_ARTIFACTS}/vagrant-go_linux_amd64" ./pkgs "${VERSION}"
         env:
-          VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VAGRANT_ARTIFACTS: ${{ inputs.vagrant-artifacts-path }}
+          VERSION: ${{ inputs.vagrant-version }}
       - name: Cache Vagrant rpms
         run: ./.ci/create-cache "${CACHE_ID}" ./pkgs
         env:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,13 +1,29 @@
 on:
   workflow_call:
     inputs:
-      vagrant_draft_name:
-        description: Name of the Vagrant repository draft release containing gem for build
-        required: false
+      vagrant-artifacts-name:
+        description: Name of upload containing Vagrant build artifacts
+        required: true
         type: string
-      vagrant_release_name:
-        description: Name of the Vagrant repository release containing gem for build
-        required: false
+      vagrant-artifacts-path:
+        description: Path used for Vagrant build artifacts
+        required: true
+        type: string
+      vagrant-gem-name:
+        description: Name of upload containing the Vagrant RubyGem
+        required: true
+        type: string
+      vagrant-gem-path:
+        description: Path used for the Vagrant RubyGem (directory)
+        required: true
+        type: string
+      vagrant-version:
+        description: Version of Vagrant being built
+        required: true
+        type: string
+      vagrant-shasum:
+        description: The shasum of the Vagrant RubyGem
+        required: true
         type: string
     outputs:
       msi-64-signed-id:
@@ -16,9 +32,6 @@ on:
       msi-32-signed-id:
         description: Cache identifier for Windows i686 msi package
         value: ${{ jobs.info.outputs.msi-32-signed-id }}
-      vagrant-version:
-        description: Version of Vagrant package built
-        value: ${{ jobs.info.outputs.vagrant-version }}
 
 jobs:
   info:
@@ -28,8 +41,6 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      vagrant-version: ${{ steps.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-artifacts.outputs.vagrant-shasum }}
       substrates-unsigned-id: ${{ steps.inspect.outputs.substrates-unsigned-id }}
       substrates-unsigned-exists: ${{ steps.inspect.outputs.substrates-unsigned-exists }}
       substrates-32-signed-id: ${{ steps.inspect.outputs.substrates-32-signed-id }}
@@ -74,31 +85,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant RubyGem
-        id: vagrant-artifacts
-        run: ./.ci/fetch-vagrant-files
-        env:
-          VAGRANT_DRAFT_NAME: ${{ inputs.draft_name }}
-          VAGRANT_RELEASE_NAME: ${{ inputs.release_name }}
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Gather information
         id: inspect
         run: ./.ci/windows-build-information
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_SHASUM: ${{ steps.vagrant-gem.outputs.vagrant-shasum }}
-      - name: Store Vagrant RubyGem
-        if: ${{ steps.inspect.outputs.gems-32-unsigned-exists != 'true' || steps.inspect.outputs.gems-64-unsigned-exists != 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: vagrant-rubygem-win
-          path: ./gem
+          VAGRANT_SHASUM: ${{ inputs.vagrant-shasum }}
       - name: Build launchers
         if: ${{ steps.inspect.outputs.substrates-unsigned-exists != 'true' }}
         run: make bin/launcher/windows
@@ -317,8 +309,8 @@ jobs:
       - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-win
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Install Vagrant RubyGem
         run: powershell -File .\package\windows\generate_package_contents.ps1 -Substrate .\signed-substrates\substrate_windows_386.zip -VagrantGem .\gem\vagrant.gem -Destination .\installed
       - name: Upload Installed Gems
@@ -360,8 +352,8 @@ jobs:
       - name: Fetch Vagrant RubyGem
         uses: actions/download-artifact@v3
         with:
-          name: vagrant-rubygem-win
-          path: ./gem
+          name: ${{ inputs.vagrant-gem-name }}
+          path: ${{ inputs.vagrant-gem-path }}
       - name: Install Vagrant RubyGem
         run: powershell -File .\package\windows\generate_package_contents.ps1 -Substrate .\signed-substrates\substrate_windows_x86_64.zip -VagrantGem .\gem\vagrant.gem -Destination .\installed
       - name: Upload Installed Gems
@@ -556,7 +548,7 @@ jobs:
       - name: Build 32 Bit Windows MSI
         run: powershell -File .\package\windows\build_vagrant_msi.ps1 -Substrate .\signed-substrates\substrate_windows_386.zip -Installed .\signed-gems\installed_windows_386.zip -VagrantVersion ${env:VagrantVersion} -Destination .\pkg
         env:
-          VagrantVersion: ${{ needs.info.outputs.vagrant-version }}
+          VagrantVersion: ${{ inputs.vagrant-version }}
       - name: Upload 32 Bit Vagrant MSI
         uses: actions/upload-artifact@v3
         with:
@@ -582,7 +574,7 @@ jobs:
       - name: Build 64 Bit Windows MSI
         run: powershell -File .\package\windows\build_vagrant_msi.ps1 -Substrate .\signed-substrates\substrate_windows_x86_64.zip -Installed .\signed-gems\installed_windows_x86_64.zip -VagrantVersion ${env:VagrantVersion} -Destination .\pkg
         env:
-          VagrantVersion: ${{ needs.info.outputs.vagrant-version }}
+          VagrantVersion: ${{ inputs.vagrant-version }}
       - name: Upload 64 Bit Vagrant MSI
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/dev-appimage-installer.yml
+++ b/.github/workflows/dev-appimage-installer.yml
@@ -1,20 +1,40 @@
 on:
+  repository_dispatch:
+    types:
+      - build-appimage
   push:
     branches:
       - 'build-appimage-*'
+  workflow_dispatch:
 
 jobs:
+  vagrant-artifacts:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-appimage-package:
     if: github.repository == 'hashicorp/vagrant-builders'
     name: Build appimage package
+    needs: [vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-appimage.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish:
     if: github.repository == 'hashicorp/vagrant-builders'
-    needs: [build-appimage-package]
+    needs: [vagrant-artifacts, build-appimage-package]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,4 +50,4 @@ jobs:
         run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_VERSION: ${{ needs.build-appimage-package.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-archlinux-installer.yml
+++ b/.github/workflows/dev-archlinux-installer.yml
@@ -1,20 +1,40 @@
 on:
+  repository_dispatch:
+    types:
+      - build-arch
   push:
     branches:
       - 'build-arch-*'
+  workflow_dispatch:
 
 jobs:
+  vagrant-artifacts:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-archlinux-package:
     if: github.repository == 'hashicorp/vagrant-builders'
     name: Build Arch Linux Package
+    needs: [vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-arch.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish:
     if: github.repository == 'hashicorp/vagrant-builders'
-    needs: [build-archlinux-package]
+    needs: [vagrant-artifacts, build-archlinux-package]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,4 +50,4 @@ jobs:
         run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_VERSION: ${{ needs.build-archlinux-package.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-debs-installer.yml
+++ b/.github/workflows/dev-debs-installer.yml
@@ -1,20 +1,40 @@
 on:
+  repository_dispatch:
+    types:
+      - build-debs
   push:
     branches:
       - 'build-debs-*'
+  workflow_dispatch:
 
 jobs:
+  vagrant-artifacts:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-deb-packages:
     if: github.repository == 'hashicorp/vagrant-builders'
     name: Build deb packages
+    needs: [vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-debs.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish:
     if: github.repository == 'hashicorp/vagrant-builders'
-    needs: [build-deb-packages]
+    needs: [vagrant-artifacts, build-deb-packages]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,4 +50,4 @@ jobs:
         run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_VERSION: ${{ needs.build-deb-packages.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-macos-installer.yml
+++ b/.github/workflows/dev-macos-installer.yml
@@ -1,20 +1,40 @@
 on:
+  repository_dispatch:
+    types:
+      - build-macos
   push:
     branches:
       - 'build-macos-*'
+  workflow_dispatch:
 
 jobs:
+  vagrant-artifacts:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-macos-package:
     if: github.repository == 'hashicorp/vagrant-builders'
     name: Build macOS package
+    needs: [vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-macos.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish:
     if: github.repository == 'hashicorp/vagrant-builders'
-    needs: [build-macos-package]
+    needs: [vagrant-artifacts, build-macos-package]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,4 +50,4 @@ jobs:
         run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_VERSION: ${{ needs.build-macos-package.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-rpms-installer.yml
+++ b/.github/workflows/dev-rpms-installer.yml
@@ -1,20 +1,40 @@
 on:
+  repository_dispatch:
+    types:
+      - build-rpms
   push:
     branches:
       - 'build-rpms-*'
+  workflow_dispatch:
 
 jobs:
+  vagrant-artifacts:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-rpm-packages:
     if: github.repository == 'hashicorp/vagrant-builders'
     name: Build rpm packages
+    needs: [vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-rpms.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish:
     if: github.repository == 'hashicorp/vagrant-builders'
-    needs: [build-rpm-packages]
+    needs: [vagrant-artifacts, build-rpm-packages]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,4 +50,4 @@ jobs:
         run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_VERSION: ${{ needs.build-rpm-packages.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-windows-installer.yml
+++ b/.github/workflows/dev-windows-installer.yml
@@ -1,20 +1,40 @@
 on:
+  repository_dispatch:
+    types:
+      - build-windows
   push:
     branches:
       - 'build-windows-*'
+  workflow_dispatch:
 
 jobs:
+  vagrant-artifacts:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-windows-packages:
     if: github.repository == 'hashicorp/vagrant-builders'
     name: Build Windows Packages
+    needs: [vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-windows.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish:
     if: github.repository == 'hashicorp/vagrant-builders'
-    needs: [build-windows-packages]
+    needs: [vagrant-artifacts, build-windows-packages]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,4 +55,4 @@ jobs:
         run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VAGRANT_VERSION: ${{ needs.build-windows-packages.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,14 +1,26 @@
 on:
-  schedule:
-    - cron: '0 2 * * *'
+  repository_dispatch:
+    types:
+      - nightlies
+      - build
   push:
     branches:
       - 'nightlies'
   workflow_dispatch:
 
 jobs:
-  info:
+  vagrant-artifacts:
     if: github.repository == 'hashicorp/vagrant-builders'
+    name: Build Core Vagrant Artifacts
+    permissions:
+      contents: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
+  info:
+    name: Generate Build Information
+    if: github.repository == 'hashicorp/vagrant-builders'
+    needs: [vagrant-artifacts]
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
       contents: write
@@ -16,9 +28,6 @@ jobs:
     outputs:
       release-name: ${{ steps.generate.outputs.release-name }}
       release-exists: ${{ steps.generate.outputs.release-exists }}
-      vagrant-version: ${{ steps.vagrant-info.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-info.outputs.vagrant-shasum }}
-      vagrant-commit-id: ${{ steps.vagrant-info.outputs.vagrant-commit-id }}
     steps:
       - name: Authentication
         id: vault-auth
@@ -34,82 +43,113 @@ jobs:
             kv/data/teams/vagrant/hashibot vagrant_token;
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Install Ruby
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant Info
-        id: vagrant-info
-        run: ./.ci/fetch-vagrant-info
-        env:
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
       - name: Generate Nightly Information
         id: generate
         run: ./.ci/nightly-information "${VAGRANT_VERSION}" "${VAGRANT_SHA}"
         env:
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
-          VAGRANT_VERSION: ${{ steps.vagrant-info.outputs.vagrant-version }}
-          VAGRANT_SHA: ${{ steps.vagrant-info.outputs.vagrant-shasum }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+          VAGRANT_SHA: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
   build-appimage-package:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build appimage package
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-appimage.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-archlinux-package:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build Arch Linux Package
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-arch.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-deb-packages:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build deb packages
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-debs.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-macos-package:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build macOS package
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-macos.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-rpm-packages:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build rpm packages
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-rpms.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-windows-packages:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build Windows Packages
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-windows.yml
+    with:
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   nightlies-release:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Nightly Release
-    needs: [info, build-appimage-package, build-archlinux-package, build-deb-packages, build-macos-package, build-rpm-packages, build-windows-packages]
+    needs: [vagrant-artifacts, info, build-appimage-package, build-archlinux-package, build-deb-packages, build-macos-package, build-rpm-packages, build-windows-packages]
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
       id-token: write
@@ -168,6 +208,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.build-windows-packages.outputs.msi-64-signed-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch Vagrant Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+          path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      - name: Add Build Artifacts
+        run: cp "${VAGRANT_ARTIFACTS}/"* ./pkg
+        env:
+          VAGRANT_ARTIFACTS: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
       - name: Generate shasums
         run: ./.ci/nightlies-shasums ./pkg "${VAGRANT_VERSION}"
         env:
@@ -175,10 +224,10 @@ jobs:
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
-          VAGRANT_VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       - name: Publish Nightly Build
-        run: ./.ci/publish-nightlies "${RELEASE_NAME}" "${COMMIT_ID}" ./pkg
+        run: ./.ci/publish-nightlies "${RELEASE_NAME}" "${COMMIT_ID:-main}" ./pkg
         env:
-          COMMIT_ID: ${{ needs.info.outputs.vagrant-commit-id }}
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
           RELEASE_NAME: ${{ needs.info.outputs.release-name }}
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,116 +1,135 @@
 on:
-  push:
-    tags: 'v*'
+  repository_dispatch:
+    types:
+      - hashicorp-release
 
 jobs:
-  info:
+  vagrant-artifacts:
     if: github.repository == 'hashicorp/vagrant-builders'
-    name: Generate info
-    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    name: Build Core Vagrant Artifacts
     permissions:
       contents: write
-      id-token: write
+    uses: ./.github/workflows/vagrant-artifacts.yml
+    with:
+      vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
+  info:
+    if: github.repository == 'hashicorp/vagrant-builders'
+    name: Validate Release Tag
+    runs-on: ubuntu-latest
     outputs:
-      vagrant-version: ${{ steps.vagrant-info.outputs.vagrant-version }}
-      vagrant-shasum: ${{ steps.vagrant-info.outputs.vagrant-shasum }}
-      vagrant-commit-id: ${{ steps.vagrant-info.outputs.vagrant-commit-id }}
-      vagrant-tag: ${{ steps.vagrant-info.outputs.vagrant-tag }}
+      vagrant-tag: ${{ steps.validate.outputs.vagrant-tag }}
+      release-exists: ${{ steps.validate.outputs.release-exists }}
     steps:
-      - name: Authentication
-        id: vault-auth
-        run: vault-auth
-      - name: Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v2
-        with:
-          url: ${{ steps.vault-auth.outputs.addr }}
-          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
-          token: ${{ steps.vault-auth.outputs.token }}
-          secrets:
-            kv/data/teams/vagrant/hashibot vagrant_token;
-      - name: Code Checkout
-        uses: actions/checkout@v3
-      - name: Install Ruby
+      - name: Validate
+        id: validate
         run: |
-          sudo apt-get update
-          sudo apt-get install -yq ruby
+          . ./.ci/load-ci.sh
+          if ! valid_release_version "${VAGRANT_TAG}"; then
+            failure "Invalid Vagrant release tag value (%s)" "${VAGRANT_TAG}"
+          fi
+          printf "vagrant-tag=%s\n" "${VAGRANT_TAG}"
         env:
-          DEBIAN_FRONTEND: noninteractive
-      - name: Fetch Vagrant Info
-        id: vagrant-info
-        run: ./.ci/fetch-vagrant-info --tag-required
-        env:
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
+          VAGRANT_TAG: ${{ github.event.client_payload.tag }}
   build-appimage-package:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Build appimage package
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-appimage.yml
     with:
-      vagrant_release_name: ${{ needs.info.outputs.vagrant-tag }}
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-archlinux-package:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Build Arch Linux Package
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-arch.yml
     with:
-      vagrant_release_name: ${{ needs.info.outputs.vagrant-tag }}
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-deb-packages:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Build deb packages
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-debs.yml
     with:
-      vagrant_release_name: ${{ needs.info.outputs.vagrant-tag }}
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-macos-package:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Build macOS package
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-macos.yml
     with:
-      vagrant_release_name: ${{ needs.info.outputs.vagrant-tag }}
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-rpm-packages:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Build rpm packages
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-rpms.yml
     with:
-      vagrant_release_name: ${{ needs.info.outputs.vagrant-tag }}
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   build-windows-packages:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Build Windows Packages
-    needs: [info]
+    needs: [info, vagrant-artifacts]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/build-windows.yml
     with:
-      vagrant_release_name: ${{ needs.info.outputs.vagrant-tag }}
+      vagrant-artifacts-name: ${{ needs.vagrant-artifacts.outputs.artifacts-name }}
+      vagrant-artifacts-path: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
+      vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
+      vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
+      vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   release:
-    if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
+    if: github.repository == 'hashicorp/vagrant-builders'
     name: Release
-    needs: [info, build-appimage-package, build-archlinux-package, build-deb-packages, build-macos-package, build-rpm-packages, build-windows-packages]
+    needs: [info, vagrant-artifacts, build-appimage-package, build-archlinux-package, build-deb-packages, build-macos-package, build-rpm-packages, build-windows-packages]
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
       id-token: write
@@ -177,7 +196,7 @@ jobs:
         run: ./.ci/publish-release "${VAGRANT_VERSION}" ./pkg
         env:
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.hashicorp_release_github_token }}
-          VAGRANT_VERSION: ${{ needs.info.outputs.vagrant-version }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}

--- a/.github/workflows/vagrant-artifacts.yml
+++ b/.github/workflows/vagrant-artifacts.yml
@@ -1,0 +1,111 @@
+on:
+  workflow_dispatch:
+    inputs:
+      vagrant-commit-id:
+        description: Vagrant repository commit ID
+        required: false
+        type: string
+    outputs:
+      artifacts-name: vagrant-build-artifacts
+      artifacts-path: ./vagrant-build-artifacts
+      gem-name: vagrant-build-rubygem
+      gem-path: ./gem
+      vagrant-shasum: ${{ jobs.build.outputs.vagrant-shasum }}
+      vagrant-version: ${{ jobs.build.outputs.vagrant-version }}
+      vagrant-commit-id: ${{ jobs.build.outputs.vagrant-commit-id }}
+
+jobs:
+  build:
+    name: Build Vagrant Artifacts
+    if: github.repository == 'hashicorp/vagrant-builders'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      artifacts-name: ${{ steps.names.outputs.artifacts-name }}
+      artifacts-path: ${{ steps.names.outputs.artifacts-path }}
+      gem-name: ${{ steps.names.outputs.gem-name }}
+      gem-path: ${{ steps.names.outputs.gem-path }}
+      vagrant-shasum: ${{ steps.info.outputs.vagrant-shasum }}
+      vagrant-version: ${{ steps.info.outputs.vagrant-version }}
+      vagrant-commit-id: ${{ steps.commit.outputs.vagrant-commit-id }}
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Set Names and Paths
+        id: names
+        run: |
+          printf "artifacts-name=vagrant-build-artifacts\n" >> "${GITHUB_OUTPUT}"
+          printf "artifacts-path=./vagrant-build-artifacts\n" >> "${GITHUB_OUTPUT}"
+          printf "gem-name=vagrant-build-rubygem\n" >> "${GITHUB_OUTPUT}"
+          printf "gem-path=./gem\n" >> "${GITHUB_OUTPUT}"
+      - name: Code Checkout Main
+        if: inputs.vagrant-commit-id == ''
+        uses: actions/checkout@v3
+        with:
+          repository: hashicorp/vagrant
+          ref: main
+          path: ./vagrant-source
+      - name: Code Checkout
+        if: inputs.vagrant-commit-id != ''
+        uses: actions/checkout@v3
+        with:
+          repository: hashicorp/vagrant
+          ref: ${{ inputs.vagrant-commit-id }}
+          path: ./vagrant-source
+      - name: Vagrant Commit ID
+        id: commit
+        run: ./.ci/fetch-vagrant-source-info ./vagrant-source
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch Cached Vagrant Artifacts
+        if: steps.commit.outputs.vagrant-cache-exists == 'true'
+        run: ./.ci/restore-cache "${CACHE_ID}" "${VAGRANT_ARTIFACTS}"
+        env:
+          VAGRANT_ARTIFACTS: ${{ steps.name.outputs.artifacts-path }}
+          CACHE_ID: ${{ steps.commit.outputs.vagrant-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Ruby
+        if: steps.commit.outputs.vagrant-cache-exists != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Setup Go
+        if: steps.commit.outputs.vagrant-cache-exists != 'true'
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build Vagrant Artifacts
+        if: steps.commit.outputs.vagrant-cache-exists != 'true'
+        run: ./vagrant-source/.ci/build "${VAGANT_ARTIFACTS}"
+        env:
+          VAGRANT_ARTIFACTS: ${{ steps.name.outputs.artifacts-path }}
+      - name: Cache Vagrant Artifacts
+        if: steps.commit.outputs.vagrant-cache-exists != 'true'
+        run: ./.ci/create-cache "${CACHE_ID}" "${VAGRANT_ARTIFACTS}"
+        env:
+          VAGRANT_ARTIFACTS: ${{ steps.name.outputs.artifacts-path }}
+          CACHE_ID: ${{ steps.commit.outputs.vagrant-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Vagrant Information
+        id: info
+        run: ./.ci/fetch-vagrant-info "${VAGRANT_ARTIFACTS}"
+        env:
+          VAGRANT_ARTIFACTS: ${{ steps.name.outputs.artifacts-path }}
+      - name: Upload Vagrant Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.name.outputs.artifacts-name }}
+          path: ${{ steps.name.outputs.artifacts-path }}
+      - name: Isolate Vagrant RubyGem
+        run: |
+          mkdir gem
+          cp "${VAGRANT_ARTIFACTS}/"vagrant*.gem "${VAGRANT_GEM_PATH}/vagrant.gem"
+        env:
+          VAGRANT_ARTIFACTS: ${{ steps.name.outputs.artifacts-path }}
+          VAGRANT_GEM_PATH: ${{ steps.name.outputs.gem-path }}
+      - name: Upload Vagrant RubyGem
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.name.outputs.gem-name }}
+          path: ${{ steps.name.outputs.gem-path }}


### PR DESCRIPTION
Build all artifacts (includes Vagrant RubyGem and vagrant-go) when
building packages so everything can be signed and verified.
