### PR TITLE
Include the cacert bundle in Windows substrate

### DIFF
--- a/substrate/windows/substrate-builder
+++ b/substrate/windows/substrate-builder
@@ -314,6 +314,9 @@ mv -f "${systime_file_new}" "${systime_file}" || exit
 mkdir -p ./etc || exit
 cp "${root}/substrate/common/gemrc" ./etc/gemrc || exit
 
+# include a certificate bundle
+curl -o cacert.pem -SsLf https://curl.se/ca/cacert.pem || exit
+
 # clean out some leftover directories
 rm -rf ./_scripts ./tmp ./var
 


### PR DESCRIPTION
The cacert bundle is currently included in the 32bit build but was not
included in the 64bit build. This adds the bundle into the 64bit bundle.

Fixes hashicorp/vagrant#13156
