### PR TITLE
Set arch value for 64 bit packages

### DIFF
--- a/package/build-deb
+++ b/package/build-deb
@@ -43,6 +43,7 @@ if [[ "${installer_file}" = *"386"* ]]; then
     fpm_arch="i386"
 elif [[ "${installer_file}" = *"x86_64"* ]]; then
     arch="amd64"
+    fpm_arch="amd64"
 else
     fail "Cannot determine architecture from installer path (%s)" \
         "${installer_file}"


### PR DESCRIPTION
The `fpm_arch` variable was added to allow a custom arch value to be
passed to fpm for generating the 32 bit packages. This change properly
sets the variable when building 64 bit packages.

Fixes hashicorp/vagrant#13155
