### PR TITLE
Use universal vagrant-go binary

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -229,7 +229,7 @@ jobs:
           name: ${{ inputs.vagrant-artifacts-name }}
           path: ${{ inputs.vagrant-artifacts-path }}
       - name: Relocate Vagrant Go Binary
-        run: mkdir ./vagrant-go-signed && mv "${VAGRANT_ARTIFACTS}/vagrant-go_darwin_amd64" ./vagrant-go-signed/vagrant-go
+        run: mkdir ./vagrant-go-signed && mv "${VAGRANT_ARTIFACTS}/vagrant-go_darwin_universal" ./vagrant-go-signed/vagrant-go
         env:
           VAGRANT_ARTIFACTS: ${{ inputs.vagrant-artifacts-path }}
       - name: Sign Vagrant Go Binary


### PR DESCRIPTION
The vagrant-artifacts will now produce a universal binary for
vagrant-go. Use that as the final artifact to install into the core
package.
