### PR TITLE
Remove `--epoch` flag from deb builds

### DIFF
--- a/package/build-deb
+++ b/package/build-deb
@@ -107,7 +107,6 @@ fpm -p "${output_path}" \
     --vendor "HashiCorp" \
     --maintainer "HashiCorp <support@hashicorp.com>" \
     --url "https://www.vagrantup.com" \
-    --epoch 0 \
     --iteration "${release}" \
     --deb-user root \
     --deb-group root \


### PR DESCRIPTION
When the `--epoch` flag is included while building `.deb` packages the
resulting version value ends up being being prefixed with the epoch
value in the format of `EPOCH:VERSION-ITERATION`. Remove the epoch flag
to get the expected format without the `EPOCH:` prefix.

Fixes #274
