### PR TITLE
Update nightly to general dev builds

### DIFF
--- a/.ci/dev-build-information
+++ b/.ci/dev-build-information
@@ -13,7 +13,7 @@ if [ -z "${GITHUB_OUTPUT}" ]; then
 fi
 
 if [ "${#}" -ne 3 ]; then
-    printf "Usage: %s VERSION GEM_SHA RUN_NUMBER\n" "${0}" >&2
+    printf "Usage: %s VERSION VAGRANT_COMMIT RUN_NUMBER\n" "${0}" >&2
     exit 1
 fi
 
@@ -25,7 +25,7 @@ if [ -z "${version}" ]; then
     failure "Vagrant version is required"
 fi
 if [ -z "${sha}" ]; then
-    failure "Vagrant RubyGem shasum is required"
+    failure "Vagrant commit ID is required"
 fi
 if [ -z "${run_number}" ]; then
     failure "Run number is required"
@@ -33,15 +33,15 @@ fi
 
 run_number="$(printf "%06d" "${run_number}")"
 
-# Create the name for the nightly release
-nightly_name="${version}+${run_number}-${sha:0:7}"
-debug "nightly release name: %s" "${nightly_name}"
+# Create the name for the dev build release
+release_name="${version}+${run_number}-${sha:0:8}"
+debug "release name: %s" "${release_name}"
 
 # Create the output for the release name
-printf "release-name=%s\n" "${nightly_name}" >> "${GITHUB_OUTPUT}"
+printf "release-name=%s\n" "${release_name}" >> "${GITHUB_OUTPUT}"
 
 # Check if the nightly already exists
-if github_release_exists "vagrant" "${nightly_name}"; then
-    debug "nightly release '%s' already exists" "${nightly_name}"
+if github_release_exists "vagrant" "${release_name}"; then
+    debug "nightly release '%s' already exists" "${release_name}"
     printf "release-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi

--- a/.ci/dev-builds-shasums
+++ b/.ci/dev-builds-shasums
@@ -6,6 +6,11 @@ root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
 
 . "${root}/.ci/load-ci.sh"
 
+if [ "${#}" -ne 2 ]; then
+    printf "Usage: %s ARTIFACT_DIR VERSION\n" "${0}" >&2
+    exit 1
+fi
+
 artifact_directory="${1}"
 version="${2}"
 if [ -z "${artifact_directory}" ]; then
@@ -24,7 +29,7 @@ debug "generating shasum file for artifacts in %s" "${artifact_directory}"
 
 generate_shasums "${artifact_directory}" "vagrant" "${version}"
 
-sumfiles=( "./pkg/"*"SHA256SUMS" )
+sumfiles=( "./${artifact_directory}/"*"SHA256SUMS" )
 sumfile="${sumfiles[0]}"
 if [ ! -f "${sumfile}" ]; then
     failure "Failed to locate generated shasums file"

--- a/.ci/fetch-vagrant-source-info
+++ b/.ci/fetch-vagrant-source-info
@@ -26,10 +26,14 @@ pushd "${SOURCE_DIR}"
 commit_id="$(git rev-parse HEAD)" ||
     failure "Failed to get commit ID for Vagrant repository"
 
+# Trim the commit ID
+short_commit_id="${commit_id:0:8}"
+
 printf "vagrant-commit-id=%s\n" "${commit_id}" >> "${GITHUB_OUTPUT}"
+printf "vagrant-short-commit-id=%s\n" "${short_commit_id}" >> "${GITHUB_OUTPUT}"
 
 # Check if the initial build artifacts have already been cached
-cache_id="vagrant-${commit_id}"
+cache_id="vagrant-${short_commit_id}"
 printf "vagrant-cache-id=%s\n" "${cache_id}" >> "${GITHUB_OUTPUT}"
 
 if github_draft_release_exists "${repo_name}" "${cache_id}"; then

--- a/.ci/publish-dev-builds
+++ b/.ci/publish-dev-builds
@@ -34,6 +34,7 @@ if [ -z "${branch}" ]; then
 fi
 if [ -z "${release_type}" ]; then
     failure "Nightly/build release requires release type value"
+fi
 if [ -z "${pkg_dir}" ]; then
     failure "Package directory required for nightly/build release"
 fi
@@ -55,12 +56,13 @@ fi
 
 if [ "${release_type}" = "nightlies" ]; then
     release_body="Vagrant nightly release build"
+    debug "creating nightly vagrant release - %s" "${release_name}"
 else
-    release_body="Custom Vagrant build on [${branch}](https://github.com/hashicorp/vagrant/tree/${branch}) at [${commitish:0:7}](https://github.com/hashicorp/vagrant/commit/${commitish})"
+    release_body="Custom Vagrant build on [${branch}](https://github.com/hashicorp/vagrant/tree/${branch}) at [${commitish:0:8}](https://github.com/hashicorp/vagrant/commit/${commitish})"
+    debug "creating dev build vagrant (branch: %s) release - %s" "${branch}" "${release_name}"
 fi
 
 # Create the release
-debug "creating nightly vagrant release - %s" "${release_name}"
 release_output="$(github_create_release -o "${repo_owner}" -r "vagrant" -n "${release_name}" -t "${release_name}" -c "${commitish}" -b "${release_body}" -p -m)" ||
     failure "Could not create GitHub prerelease"
 debug "new release created: %s" "${release_output}"

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       vagrant-shasum:
-        description: The shasum of the Vagrant RubyGem
+        description: The shasum of the Vagrant RubyGem or commit
         required: true
         type: string
     outputs:

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       vagrant-shasum:
-        description: The shasum of the Vagrant RubyGem
+        description: The shasum of the Vagrant RubyGem or commit
         required: true
         type: string
     outputs:

--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       vagrant-shasum:
-        description: The shasum of the Vagrant RubyGem
+        description: The shasum of the Vagrant RubyGem or commit
         required: true
         type: string
     outputs:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       vagrant-shasum:
-        description: The shasum of the Vagrant RubyGem
+        description: The shasum of the Vagrant RubyGem or commit
         required: true
         type: string
     outputs:

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       vagrant-shasum:
-        description: The shasum of the Vagrant RubyGem
+        description: The shasum of the Vagrant RubyGem or commit
         required: true
         type: string
     outputs:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       vagrant-shasum:
-        description: The shasum of the Vagrant RubyGem
+        description: The shasum of the Vagrant RubyGem or commit
         required: true
         type: string
     outputs:

--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -45,12 +45,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Generate Nightly Information
         id: generate
-        run: ./.ci/nightly-information "${VAGRANT_VERSION}" "${VAGRANT_SHA}" "${RUN_NUMBER}"
+        run: ./.ci/dev-build-information "${VAGRANT_VERSION}" "${VAGRANT_SHORT_ID}" "${RUN_NUMBER}"
         env:
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}
           RUN_NUMBER: ${{ github.run_number }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-          VAGRANT_SHA: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+          VAGRANT_SHORT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
   build-appimage-package:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Build appimage package
@@ -65,7 +65,7 @@ jobs:
       vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
       vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
     secrets: inherit
   build-archlinux-package:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
@@ -81,7 +81,7 @@ jobs:
       vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
       vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
     secrets: inherit
   build-deb-packages:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
@@ -97,7 +97,7 @@ jobs:
       vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
       vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
     secrets: inherit
   build-macos-package:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
@@ -113,7 +113,7 @@ jobs:
       vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
       vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
     secrets: inherit
   build-rpm-packages:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
@@ -129,7 +129,7 @@ jobs:
       vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
       vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
     secrets: inherit
   build-windows-packages:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
@@ -145,9 +145,9 @@ jobs:
       vagrant-gem-name: ${{ needs.vagrant-artifacts.outputs.gem-name }}
       vagrant-gem-path: ${{ needs.vagrant-artifacts.outputs.gem-path }}
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
+      vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-short-commit-id }}
     secrets: inherit
-  nightlies-release:
+  build-release:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
     name: Nightly Release
     needs: [vagrant-artifacts, info, build-appimage-package, build-archlinux-package, build-deb-packages, build-macos-package, build-rpm-packages, build-windows-packages]
@@ -219,15 +219,15 @@ jobs:
         env:
           VAGRANT_ARTIFACTS: ${{ needs.vagrant-artifacts.outputs.artifacts-path }}
       - name: Generate shasums
-        run: ./.ci/nightlies-shasums ./pkg "${VAGRANT_VERSION}"
+        run: ./.ci/dev-build-shasums ./pkg "${VAGRANT_VERSION}"
         env:
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-      - name: Publish Nightly Build
-        run: ./.ci/publish-nightlies "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
         env:
           COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
           BRANCH: ${{ github.event.client_payload.vagrant-branch-name }}

--- a/.github/workflows/vagrant-artifacts.yml
+++ b/.github/workflows/vagrant-artifacts.yml
@@ -27,6 +27,10 @@ on:
       vagrant-commit-id:
         description: The commit ID (sha) for the Vagrant source being built
         value: ${{ jobs.build.outputs.vagrant-commit-id }}
+      vagrant-short-commit-id:
+        description: The short commit ID (sha) for the Vagrant source being built
+        value: ${{ jobs.build.outputs.vagrant-short-commit-id }}
+
 
 jobs:
   build:
@@ -43,6 +47,7 @@ jobs:
       vagrant-shasum: ${{ steps.info.outputs.vagrant-shasum }}
       vagrant-version: ${{ steps.info.outputs.vagrant-version }}
       vagrant-commit-id: ${{ steps.commit.outputs.vagrant-commit-id }}
+      vagrant-short-commit-id: ${{ steps.commit.outputs.vagrant-short-commit-id }}
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Updates nightly scripts and workflows to general dev builds. Use the
vagrant source commit ID instead of the build vagrant gem shasum value
when generating cache ids.
