### PR TITLE
Support triggered isolated dev builds

### DIFF
--- a/.github/workflows/dev-appimage-installer.yml
+++ b/.github/workflows/dev-appimage-installer.yml
@@ -33,8 +33,8 @@ jobs:
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
-  publish:
-    if: github.repository == 'hashicorp/vagrant-builders'
+  publish-local:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action != 'build-appimage'
     needs: [vagrant-artifacts, build-appimage-package]
     runs-on: ubuntu-latest
     permissions:
@@ -52,3 +52,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+  publish-vagrant:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-appimage'
+    needs: [vagrant-artifacts, build-appimage-package]
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot vagrant_token;
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-builders signore_client_id;
+            kv/data/github/hashicorp/vagrant-builders signore_client_secret;
+            kv/data/github/hashicorp/vagrant-builders signore_gpg_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch appimage package
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-appimage-package.outputs.appimage-package-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate shasums
+        run: ./.ci/dev-builds-shasums ./pkg "${VAGRANT_VERSION}"
+        env:
+          SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
+          SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+        env:
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          RELEASE_NAME: ${{ needs.info.outputs.release-name }}
+          RELEASE_TYPE: ${{ github.event.action }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}

--- a/.github/workflows/dev-archlinux-installer.yml
+++ b/.github/workflows/dev-archlinux-installer.yml
@@ -33,8 +33,8 @@ jobs:
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
-  publish:
-    if: github.repository == 'hashicorp/vagrant-builders'
+  publish-local:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action != 'build-arch'
     needs: [vagrant-artifacts, build-archlinux-package]
     runs-on: ubuntu-latest
     permissions:
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch Arch Linux package
+      - name: Fetch arch package
         run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
         env:
           CACHE_ID: ${{ needs.build-archlinux-package.outputs.arch-package-id }}
@@ -52,3 +52,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+  publish-vagrant:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-arch'
+    needs: [vagrant-artifacts, build-archlinux-package]
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot vagrant_token;
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-builders signore_client_id;
+            kv/data/github/hashicorp/vagrant-builders signore_client_secret;
+            kv/data/github/hashicorp/vagrant-builders signore_gpg_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch Arch Linux package
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-archlinux-package.outputs.arch-package-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate shasums
+        run: ./.ci/dev-builds-shasums ./pkg "${VAGRANT_VERSION}"
+        env:
+          SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
+          SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+        env:
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          RELEASE_NAME: ${{ needs.info.outputs.release-name }}
+          RELEASE_TYPE: ${{ github.event.action }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}

--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -150,7 +150,7 @@ jobs:
     secrets: inherit
   build-release:
     if: github.repository == 'hashicorp/vagrant-builders' && needs.info.outputs.release-exists != 'true'
-    name: Nightly Release
+    name: Vagrant GitHub Release
     needs: [vagrant-artifacts, info, build-appimage-package, build-archlinux-package, build-deb-packages, build-macos-package, build-rpm-packages, build-windows-packages]
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:

--- a/.github/workflows/dev-debs-installer.yml
+++ b/.github/workflows/dev-debs-installer.yml
@@ -33,8 +33,8 @@ jobs:
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
-  publish:
-    if: github.repository == 'hashicorp/vagrant-builders'
+  publish-local:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-debs'
     needs: [vagrant-artifacts, build-deb-packages]
     runs-on: ubuntu-latest
     permissions:
@@ -52,3 +52,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+  publish-vagrant:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-debs'
+    needs: [vagrant-artifacts, build-deb-packages]
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot vagrant_token;
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-builders signore_client_id;
+            kv/data/github/hashicorp/vagrant-builders signore_client_secret;
+            kv/data/github/hashicorp/vagrant-builders signore_gpg_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch deb packages
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-deb-packages.outputs.deb-packages-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate shasums
+        run: ./.ci/dev-builds-shasums ./pkg "${VAGRANT_VERSION}"
+        env:
+          SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
+          SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+        env:
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          RELEASE_NAME: ${{ needs.info.outputs.release-name }}
+          RELEASE_TYPE: ${{ github.event.action }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}

--- a/.github/workflows/dev-macos-installer.yml
+++ b/.github/workflows/dev-macos-installer.yml
@@ -33,8 +33,8 @@ jobs:
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
-  publish:
-    if: github.repository == 'hashicorp/vagrant-builders'
+  publish-local:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action != 'build-macos'
     needs: [vagrant-artifacts, build-macos-package]
     runs-on: ubuntu-latest
     permissions:
@@ -52,3 +52,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+  publish-vagrant:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-macos'
+    needs: [vagrant-artifacts, build-macos-package]
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot vagrant_token;
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-builders signore_client_id;
+            kv/data/github/hashicorp/vagrant-builders signore_client_secret;
+            kv/data/github/hashicorp/vagrant-builders signore_gpg_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch macOS DMG
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-macos-package.outputs.dmg-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate shasums
+        run: ./.ci/dev-builds-shasums ./pkg "${VAGRANT_VERSION}"
+        env:
+          SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
+          SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+        env:
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          RELEASE_NAME: ${{ needs.info.outputs.release-name }}
+          RELEASE_TYPE: ${{ github.event.action }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}

--- a/.github/workflows/dev-rpms-installer.yml
+++ b/.github/workflows/dev-rpms-installer.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       vagrant-commit-id: ${{ github.event.client_payload.commit_id }}
   build-rpm-packages:
-    if: github.repository == 'hashicorp/vagrant-builders'
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action != 'build-rpms'
     name: Build rpm packages
     needs: [vagrant-artifacts]
     permissions:
@@ -33,7 +33,7 @@ jobs:
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
-  publish:
+  publish-local:
     if: github.repository == 'hashicorp/vagrant-builders'
     needs: [vagrant-artifacts, build-rpm-packages]
     runs-on: ubuntu-latest
@@ -52,3 +52,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+  publish-vagrant:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-rpms'
+    needs: [vagrant-artifacts, build-rpm-packages]
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot vagrant_token;
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-builders signore_client_id;
+            kv/data/github/hashicorp/vagrant-builders signore_client_secret;
+            kv/data/github/hashicorp/vagrant-builders signore_gpg_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch rpm packages
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-rpm-packages.outputs.rpm-packages-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate shasums
+        run: ./.ci/dev-builds-shasums ./pkg "${VAGRANT_VERSION}"
+        env:
+          SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
+          SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+        env:
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          RELEASE_NAME: ${{ needs.info.outputs.release-name }}
+          RELEASE_TYPE: ${{ github.event.action }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}

--- a/.github/workflows/dev-windows-installer.yml
+++ b/.github/workflows/dev-windows-installer.yml
@@ -33,8 +33,8 @@ jobs:
       vagrant-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
-  publish:
-    if: github.repository == 'hashicorp/vagrant-builders'
+  publish-local:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action != 'build-windows'
     needs: [vagrant-artifacts, build-windows-packages]
     runs-on: ubuntu-latest
     permissions:
@@ -57,3 +57,55 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+  publish-vagrant:
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-windows'
+    needs: [vagrant-artifacts, build-windows-packages]
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot vagrant_token;
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-builders signore_client_id;
+            kv/data/github/hashicorp/vagrant-builders signore_client_secret;
+            kv/data/github/hashicorp/vagrant-builders signore_gpg_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Fetch 32 Bit Windows Package
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-windows-packages.outputs.msi-32-signed-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch 64 Bit Windows Package
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-windows-packages.outputs.msi-64-signed-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate shasums
+        run: ./.ci/dev-builds-shasums ./pkg "${VAGRANT_VERSION}"
+        env:
+          SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id }}
+          SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_SECRET }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_gpg_signer }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
+          VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+      - name: Publish Dev Build
+        run: ./.ci/publish-dev-builds "${RELEASE_NAME}" "${COMMIT_ID:-main}" "${BRANCH:-main}" "${RELEASE_TYPE}" ./pkg
+        env:
+          COMMIT_ID: ${{ needs.vagrant-artifacts.outputs.vagrant-commit-id }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          RELEASE_NAME: ${{ needs.info.outputs.release-name }}
+          RELEASE_TYPE: ${{ github.event.action }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.vagrant_token }}


### PR DESCRIPTION
Allow triggering development builds of specific platforms and publishing
the resulting package on the Vagrant repository. Let workflow dispatches
and branch matching continue to work for local package build testing and
publish the result to the local repository.
