### PR TITLE
Add architectures to installer config

### DIFF
--- a/.ci/macos-substrate-combiner
+++ b/.ci/macos-substrate-combiner
@@ -127,16 +127,6 @@ debug "unpacking x86 substrate"
 unzip -q "${x86_substrate}"
 popd
 
-# The arm embedded bin directory will contain a stub executable
-# which is used for generating fat files of standalone x86 files.
-# Build the path and verify it exists.
-arm_stub="${arm_dir}/embedded/bin/stub"
-if [ ! -f "${arm_stub}" ]; then
-    failure "Missing arm stub executable (%s)" "${arm_stub}"
-fi
-# Path where stub will be relocated
-universal_arm_stub="${universal_dir}/embedded/bin/stub"
-
 # We now need to create two lists of files. The first is the
 # list of executables and second is the list of libraries
 shopt -s globstar || fail "Could not enable globstar bash option"
@@ -252,10 +242,11 @@ for x86_path in "${x86_executable_files[@]}"; do
     mkdir -p "${universal_dirname}" ||
         fail "Could not create directory: %s" "${universal_dirname}"
 
-    debug "creating fat file of %s using arm stub and installing %s" "${partial_name}" "${universal_path}"
-    go run github.com/randall77/makefat "${universal_path}" "${x86_path}" "${arm_stub}" ||
-        failure "Could not create fat binary (source: %s dest: %s)" \
-            "${x86_path}" "${universal_path}"
+    debug "installing x86 only file: %s" "${x86_path}"
+    # And finally move the file
+    mv "${x86_path}" "${universal_path}" ||
+        fail "Failed to relocate file to universal path (source: %s dest: %s)" \
+                "${x86_path}" "${universal_path}"
 done
 
 # Now arm libraries
@@ -308,10 +299,11 @@ for x86_path in "${x86_library_files[@]}"; do
     mkdir -p "${universal_dirname}" ||
         fail "Could not create directory: %s" "${universal_dirname}"
 
-    debug "creating fat file of %s using arm stub and installing %s" "${partial_name}" "${universal_path}"
-    go run github.com/randall77/makefat "${universal_path}" "${x86_path}" "${arm_stub}" ||
-        failure "Could not create fat binary (source: %s dest: %s)" \
-            "${x86_path}" "${universal_path}"
+    debug "installing x86 only file: %s" "${x86_path}"
+    # And finally move the file
+    mv "${x86_path}" "${universal_path}" ||
+        fail "Failed to relocate x86 file to universal path (source: %s dest: %s)" \
+                "${x86_path}" "${universal_path}"
 done
 
 # Move any remaining arm64 files
@@ -357,9 +349,6 @@ for x86_path in "${x86_remaining_files[@]}"; do
         fail "Failed to relocate x86 file to universal path (source: %s dest: %s)" \
                 "${x86_path}" "${universal_path}"
 done
-
-# Remove the arm stub before generating artifact
-rm -f "${universal_arm_stub}"
 
 # Now that we have our new substrate constructed, pack
 # it up to be stored

--- a/package/support/darwin/dist/vagrant.dist
+++ b/package/support/darwin/dist/vagrant.dist
@@ -15,6 +15,11 @@
          components to install. -->
     <options customize="never" />
 
+    <!-- Mark this as package as supporting host architecture for
+         x86 and arm. This will prevent macOS from requiring rosetta
+         on arm hosts -->
+    <options hostArchitectures="x86_64,arm64" />
+
     <!-- The "choices" for things that can be installed, although the
          user has no actually choice, they're still required so that
          the installer knows what to install. -->

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -862,27 +862,6 @@ if [ "${target_os}" = "darwin" ]; then
     done < <( find "${embed_libdir}" -name "*.bundle" )
 fi
 
-# For darwin builds, when the substrates are combined a
-# stub arm executable will be needed to combine with x86
-# files that do not have a matching arm path.
-if [ "${target_ident}" = "darwin_arm64" ]; then
-    stub_dir="$(mktemp -d vagrant-stub.XXXXX)" || exit
-    pushd "${stub_dir}" || exit
-    cat > main.c <<EOF
-#include <stdio.h>
-
-int main(void)
-{
-        puts("ERROR: This is a Vagrant stub that should not be executed!");
-        return 1;
-}
-EOF
-    gcc -o stub main.c || exit
-    mv ./stub "${embed_bindir}/stub" || exit
-    popd || exit
-    rm -rf "${stub_dir:?}" || exit
-fi
-
 # Install the launcher
 info "   -> Installing vagrant launcher..."
 cp "${launcher_path}" "${build_dir}/bin/vagrant" || exit


### PR DESCRIPTION
Reverts the modifications to generate fat binaries of standalone
x86 binaries using a stub arm binary. Updates the installer configuration
to list supported host architectures, which should remove the requirement
of rosetta during install on arm based macos.

ref: hashicorp/vagrant#12825
