### PR TITLE
Always apply rbconfig adjustments

### DIFF
--- a/.ci/publish-local-dev-builds
+++ b/.ci/publish-local-dev-builds
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/.ci/load-ci.sh"
+pushd "${root}"
+
+# Output to stdout if we aren't on a runner
+if [ -z "${GITHUB_OUTPUT}" ]; then
+    GITHUB_OUTPUT="/dev/stdout"
+fi
+
+if [ "${#}" -ne 2 ]; then
+    printf "Usage: %s VERSION ARTIFACT_DIR\n" "${0}" >&2
+    exit 1
+fi
+
+tag_name="${1}"
+pkg_dir="${2}"
+
+if [ -z "${tag_name}" ]; then
+    failure "Tag name is required for local publish"
+fi
+
+if [ -z "${pkg_dir}" ]; then
+    failure "Package artifact directory is required for local publish"
+fi
+
+if [[ "${tag_name}" != *"+"* ]]; then
+    tag_name="${tag_name}+${short_sha}"
+fi
+
+debug "creating local prerelease %s" "${tag_name}"
+
+if github_release_exists "${repo_name}" "${tag_name}"; then
+    warn "Local dev build (%s) already exists, removing..." "${tag_name}"
+    github_delete_release "${tag_name}" "${repo_name}"
+fi
+
+prerelease "${tag_name}" "${pkg_dir}"

--- a/.github/workflows/dev-appimage-installer.yml
+++ b/.github/workflows/dev-appimage-installer.yml
@@ -82,7 +82,7 @@ jobs:
           CACHE_ID: ${{ needs.build-appimage-package.outputs.appimage-package-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create prerelease
-        run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
+        run: .ci/publish-local-dev-builds "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-archlinux-installer.yml
+++ b/.github/workflows/dev-archlinux-installer.yml
@@ -82,7 +82,7 @@ jobs:
           CACHE_ID: ${{ needs.build-archlinux-package.outputs.arch-package-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create prerelease
-        run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
+        run: .ci/publish-local-dev-builds "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-debs-installer.yml
+++ b/.github/workflows/dev-debs-installer.yml
@@ -82,7 +82,7 @@ jobs:
           CACHE_ID: ${{ needs.build-deb-packages.outputs.deb-packages-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create prerelease
-        run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
+        run: .ci/publish-local-dev-builds "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-debs-installer.yml
+++ b/.github/workflows/dev-debs-installer.yml
@@ -68,7 +68,7 @@ jobs:
       vagrant-shasum: ${{ needs.vagrant-artifacts.outputs.vagrant-shasum }}
     secrets: inherit
   publish-local:
-    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action == 'build-debs'
+    if: github.repository == 'hashicorp/vagrant-builders' && github.event.action != 'build-debs'
     needs: [vagrant-artifacts, build-deb-packages]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/dev-macos-installer.yml
+++ b/.github/workflows/dev-macos-installer.yml
@@ -82,7 +82,7 @@ jobs:
           CACHE_ID: ${{ needs.build-macos-package.outputs.dmg-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create prerelease
-        run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
+        run: .ci/publish-local-dev-builds "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-rpms-installer.yml
+++ b/.github/workflows/dev-rpms-installer.yml
@@ -82,7 +82,7 @@ jobs:
           CACHE_ID: ${{ needs.build-rpm-packages.outputs.rpm-packages-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create prerelease
-        run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
+        run: .ci/publish-local-dev-builds "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}

--- a/.github/workflows/dev-windows-installer.yml
+++ b/.github/workflows/dev-windows-installer.yml
@@ -87,7 +87,7 @@ jobs:
           CACHE_ID: ${{ needs.build-windows-packages.outputs.msi-64-signed-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create prerelease
-        run: . .ci/load-ci.sh && prerelease "${VAGRANT_VERSION}" ./pkg
+        run: .ci/publish-local-dev-builds "${VAGRANT_VERSION}" ./pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAGRANT_VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}


### PR DESCRIPTION
When building the substrate, modify rbconfig on all builds so
the computed topdir is used. This allows for extension builds
in non-standard paths to properly locate required files.

Fixes hashicorp/vagrant#13211
