### PR TITLE
Windows extension building fixes

### DIFF
--- a/package/package.ps1
+++ b/package/package.ps1
@@ -231,6 +231,11 @@ if ($UseCache -eq $false) {
             Write-Error "Failed to install Vagrant RubyGem into packaging substrate"
         }
 
+        & "${EmbeddedDir}\mingw${PackageArch}\bin\ruby.exe" "${EmbeddedDir}\mingw${PackageArch}\bin\gem" install pkg-config --no-document
+
+        if(!$?) {
+            Write-Error "Failed to install pkg-config gem into packaging substrate"
+        }
         $BundleDir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
         [System.IO.Directory]::CreateDirectory($BundleDir) | Out-Null
 

--- a/substrate/launcher/main.go
+++ b/substrate/launcher/main.go
@@ -93,15 +93,15 @@ func main() {
 			mingwDir = "mingw32"
 			mingwArchDir = "i686-w64-mingw32"
 		}
-		cflags = "-I" + filepath.Join(embeddedDir, mingwDir, mingwArchDir, "include") +
-			" -I" + filepath.Join(embeddedDir, mingwDir, "include") +
-			" -I" + filepath.Join(embeddedDir, "usr", "include")
-		cppflags = "-I" + filepath.Join(embeddedDir, mingwDir, mingwArchDir, "include") +
-			" -I" + filepath.Join(embeddedDir, mingwDir, "include") +
-			" -I" + filepath.Join(embeddedDir, "usr", "include")
-		ldflags = "-L" + filepath.Join(embeddedDir, mingwDir, mingwArchDir, "lib") +
-			" -L" + filepath.Join(embeddedDir, mingwDir, "lib") +
-			" -L" + filepath.Join(embeddedDir, "usr", "lib")
+		cflags = "-I" + `"` + filepath.Join(embeddedDir, mingwDir, mingwArchDir, "include") + `"` +
+			" -I" + `"` + filepath.Join(embeddedDir, mingwDir, "include") + `"` +
+			" -I" + `"` + filepath.Join(embeddedDir, "usr", "include") + `"`
+		cppflags = "-I" + `"` + filepath.Join(embeddedDir, mingwDir, mingwArchDir, "include") + `"` +
+			" -I" + `"` + filepath.Join(embeddedDir, mingwDir, "include") + `"` +
+			" -I" + `"` + filepath.Join(embeddedDir, "usr", "include") + `"`
+		ldflags = "-L" + `"` + filepath.Join(embeddedDir, mingwDir, mingwArchDir, "lib") + `"` +
+			" -L" + `"` + filepath.Join(embeddedDir, mingwDir, "lib") + `"` +
+			" -L" + `"` + filepath.Join(embeddedDir, "usr", "lib") + `"`
 	} else {
 		cppflags = "-I" + filepath.Join(embeddedDir, "include") +
 			" -I" + filepath.Join(embeddedDir, "include", "libxml2")

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -616,6 +616,10 @@ if needs_build "${tracker_file}" "readline"; then
 fi
 
 # openssl
+#
+# NOTE: a variant is defined for linux to build a lib with a custom
+#       name (will result in libssl-vagrant.so in this case). this is
+#       done to prevent issues when attempting to load the library.
 if needs_build "${tracker_file}" "openssl"; then
     info "   -> Building openssl..."
     openssl_url="${dep_cache}/${openssl_file}"


### PR DESCRIPTION
Adds path quoting to all compiler and linker flags set into
env vars. Installs the `pkg-config` rubygem to allow better
build configuration.
