### PR TITLE
Fixes for runner updates

### DIFF
--- a/.ci/centos-substrate
+++ b/.ci/centos-substrate
@@ -39,9 +39,8 @@ chroot_dir="/var/chroot/centos"
 project_name="${root##*/}"
 
 # Create the chroot
-# NOTE: We always create 64 bit chroot for centos
 debug "creating centos chroot"
-"${root}/.ci/helpers/centos-chroot-create" "64" "${chroot_dir}" ||
+"${root}/.ci/helpers/centos-chroot-create" "${chroot_dir}" ||
     failure "Could not create centos chroot environment"
 
 # The initial chroot is created. Now we need to get it prepared

--- a/.ci/helpers/centos-chroot-create
+++ b/.ci/helpers/centos-chroot-create
@@ -21,8 +21,7 @@ if [ "$(id -u)" != "0" ]; then
     failure "Script must be run as root"
 fi
 
-substrate_arch="${1?Chroot architecture required}"
-chroot_dir="${2?Path to chroot is required}"
+chroot_dir="${1?Path to chroot is required}"
 mkdir -p "${chroot_dir}" || exit
 pushd "${chroot_dir}"
 chroot_dir="$(pwd)" || exit
@@ -36,24 +35,14 @@ apt-get install -qy rinse ||
 
 # Collect arguments for passing to rinse
 rinse_args=(
-    "--distribution" "centos-6"
+    "--distribution" "centos-7"
     "--directory" "${chroot_dir}"
     "--post-install" "${root}/.ci/helpers/centos-chroot-post-install"
     "--before-post-install" "${root}/.ci/helpers/centos-chroot-repo-configure"
     "--after-post-install" "${root}/.ci/helpers/centos-chroot-repo-finalize"
+    "--arch" "amd64"
+    "--mirror" "http://archive.kernel.org/centos-vault/7/os/x86_64/Packages/"
 )
-
-if [ "${substrate_arch}" = "64" ]; then
-    rinse_args+=(
-        "--arch" "amd64"
-        "--mirror" "http://archive.kernel.org/centos-vault/6.10/os/x86_64/Packages/"
-    )
-else
-    rinse_args+=(
-        "--arch" "i386"
-        "--mirror" "http://archive.kernel.org/centos-vault/6.10/os/i386/Packages/"
-    )
-fi
 
 # NOTE: rinse command will fail unpacking the udev package due to a missing
 # directory. To workaround this, we just create the directory first

--- a/.ci/helpers/centos-chroot-repo-configure
+++ b/.ci/helpers/centos-chroot-repo-configure
@@ -6,13 +6,49 @@ prefix="${1?Prefix required}"
 /usr/lib/rinse/common/15-mount-proc.sh "${prefix}" || exit
 /usr/lib/rinse/common/20-dev-zero.sh "${prefix}" || exit
 
-sed -i 's/$releasever/6.10/' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
-#sed -i 's/\/centos//' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
-sed -i 's/mirror.centos/vault.centos/' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
-sed -i 's/^#baseurl/baseurl/' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
-sed -i 's/^mirrorlist/#mirrorlist/' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
+pushd "${prefix}/etc/yum.repos.d" || exit
 
-sed -i 's/vault.centos.org/archive.kernel.org\/centos-vault/' \
-    "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
+# Delete all the repo configurations
+rm -f ./*.repo
 
-sed -i 's/https:/http:/' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
+# Install custom configuration
+cat <<-EOF EOF > centos.repo
+name=CentOS-7 - Base
+baseurl=http://archive.kernel.org/centos-vault/centos/7/os/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+name=CentOS-7 - Updates
+baseurl=http://archive.kernel.org/centos-vault/centos/7/updates/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+name=CentOS-7 - Extras
+baseurl=http://archive.kernel.org/centos-vault/centos/7/extras/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+name=CentOS-7 - CentOSPlus
+baseurl=http://archive.kernel.org/centos-vault/centos/7/centosplus/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+name=CentOS-7 - Fasttrack
+baseurl=http://archive.kernel.org/centos-vault/centos/7/fasttrack/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+name=CentOS-7 - SCLo rh
+baseurl=http://archive.kernel.org/centos-vault/centos/7/sclo/\$basearch/rh
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+EOF
+
+popd || exit

--- a/.ci/helpers/centos-chroot-repo-finalize
+++ b/.ci/helpers/centos-chroot-repo-finalize
@@ -2,5 +2,10 @@
 
 prefix="${1?Prefix required}"
 
-chroot "${prefix}" yum install -y -q ca-certificates || exit
-sed -i 's/http:/https:/' "${prefix}/etc/yum.repos.d/CentOS-Base.repo" || exit
+# Update and reinstall packages that are broken due to missing dependencies
+# on initial bootstrap
+
+chroot "${prefix}" yum update -y -q binutils coreutils gawk initscripts krb5-libs \
+    libcurl ncurses openldap util-linux yum elfutils-libs glib2 yum-utils rpm
+
+chroot "${prefix}" yum reinstall -y -q crontabs ncurses-libs neon openssl-libs pam pygpgme

--- a/.ci/helpers/centos-chroot-setup
+++ b/.ci/helpers/centos-chroot-setup
@@ -14,36 +14,6 @@ if [ "$(id -u)" != "0" ]; then
     failure "Script must be run as root"
 fi
 
-if [ -f /.is-32-bit ]; then
-    arch="i386"
-else
-    arch="x86_64"
-fi
-
-debug "installing scl repository for updated build tools"
-setarch "${arch}" yum install -y -q centos-release-scl || exit
-
-debug "updating scl repo list"
-sed -i 's/\/centos//' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-sed -i 's/mirror.centos/vault.centos/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-sed -i 's/buildlogs.centos/vault.centos/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-sed -i 's/debuginfo.centos/vault.centos/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-sed -i 's/^# *baseurl/baseurl/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-sed -i 's/^mirrorlist/#mirrorlist/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-
-sed -i 's/\/centos//' /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-sed -i 's/mirror.centos/vault.centos/' /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-sed -i 's/buildlogs.centos/vault.centos/' /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-sed -i 's/debuginfo.centos/vault.centos/' /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-sed -i 's/^# *baseurl/baseurl/' /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-sed -i 's/^mirrorlist/#mirrorlist/' /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-
-debug "updating scl to kernel.org repo"
-sed -i 's/vault.centos.org/archive.kernel.org\/centos-vault\/centos/' \
-    /etc/yum.repos.d/CentOS-SCLo-scl.repo || exit
-sed -i 's/vault.centos.org/archive.kernel.org\/centos-vault\/centos/' \
-    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo || exit
-
 # Now do an intial update
 debug "running system update"
 yum update -y

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -82,6 +82,8 @@ jobs:
           go-version-file: go.mod
       - name: Build Launchers
         run: make bin/launcher/linux-x86_64
+      - name: Trigger LXD install
+        run: sudo lxd
       - name: Enable LXD
         run: sudo usermod -a -G lxd "${USER}"
       - name: Build Substrate


### PR DESCRIPTION
This includes some fixes required due to the runners OS upgrade.
Rinse only supports centos 7, so builds have been updated accordingly.
LXD is installed as a snap on-demand, so ensure it is installed prior
to invoking it.
