### PR TITLE
Adjust `-std` for Ruby windows build

### DIFF
--- a/substrate/windows/ruby-build/PKGBUILD
+++ b/substrate/windows/ruby-build/PKGBUILD
@@ -46,6 +46,10 @@ build() {
     CFLAGS+=" -Wno-incompatible-pointer-types"
   fi
 
+  # NOTE: builds currently fail with gcc 15 which sets
+  # -std=23. reverting it to -std=17 resolves the issue.
+  CFLAGS+=" -std=17"
+
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Adjust the `-std` value when building Ruby on Windows to be `17`.
GCC 15 defaults it to `23` which results in the build failing.
