### PR TITLE
Add patches for Ruby Windows build

### DIFF
--- a/substrate/windows/ruby-build/0001-configure-clock.patch
+++ b/substrate/windows/ruby-build/0001-configure-clock.patch
@@ -1,0 +1,18 @@
+--- a/include/ruby/win32.h
++++ b/include/ruby/win32.h
+@@ -125,8 +125,15 @@
+ #define O_SHARE_DELETE 0x20000000 /* for rb_w32_open(), rb_w32_wopen() */
+ 
+ typedef int clockid_t;
++#if defined(__MINGW32__)
++#undef CLOCK_PROCESS_CPUTIME_ID
++#undef CLOCK_THREAD_CPUTIME_ID
++#undef CLOCK_REALTIME_COARSE
++#endif
++#if defined(HAVE_CLOCK_GETTIME) && !defined(CLOCK_REALTIME)
+ #define CLOCK_REALTIME  0
+ #define CLOCK_MONOTONIC 1
++#endif
+ 
+ #undef utime
+ #undef lseek

--- a/substrate/windows/ruby-build/0002-clock-fn.patch
+++ b/substrate/windows/ruby-build/0002-clock-fn.patch
@@ -1,0 +1,28 @@
+--- a/win32/win32.c
++++ b/win32/win32.c
+@@ -4889,6 +4889,7 @@
+     return 0;
+ }
+ 
++#if !defined(__MINGW32__) || !defined(HAVE_CLOCK_GETTIME)
+ /* License: Ruby's */
+ int
+ clock_gettime(clockid_t clock_id, struct timespec *sp)
+@@ -4928,7 +4929,9 @@
+         return -1;
+     }
+ }
++#endif
+ 
++#if !defined(__MINGW32__) || !defined(HAVE_CLOCK_GETRES)
+ /* License: Ruby's */
+ int
+ clock_getres(clockid_t clock_id, struct timespec *sp)
+@@ -4956,6 +4959,7 @@
+         return -1;
+     }
+ }
++#endif
+ 
+ /* License: Ruby's */
+ static char *

--- a/substrate/windows/ruby-build/PKGBUILD
+++ b/substrate/windows/ruby-build/PKGBUILD
@@ -26,8 +26,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-gdbm"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('44ae70fee043da3ce48289b7a52618ebe32dc083253993d486211c7e445c8642')
+source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+       "0001-configure-clock.patch"
+       "0002-clock-fn.patch")
+sha256sums=('44ae70fee043da3ce48289b7a52618ebe32dc083253993d486211c7e445c8642'
+            '2c6040ca3bac3a6d3ee2b1e2926ae41f59a4266ab3afaea98058240a082acdc0'
+            'e2bcf6c7f0e4d84cdb121a17e46fbf9672204aba6254d10c3c419465758435dc')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  apply_patch_with_msg "0001-configure-clock.patch" "0002-clock-fn.patch"
+}
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -47,7 +56,7 @@ build() {
   fi
 
   # NOTE: builds currently fail with gcc 15 which sets
-  # -std=23. reverting it to -std=17 resolves the issue.
+  # -std=c23. reverting it to -std=c17 resolves the issue.
   CFLAGS+=" -std=c17"
 
   ../${_realname}-${pkgver}/configure \


### PR DESCRIPTION
Backports a couple patches from Ruby HEAD to build correctly
on Windows

* https://github.com/ruby/ruby/commit/46e4c8673747de96838d2c5dec37446d23d99d88
* https://github.com/ruby/ruby/commit/3e47e7a499acd256be549935fcb559d3c82e556c

Patches Ruby for building on Windows to handle
