### PR TITLE
workflow updates to handle unified docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
   post-release-github-release:
     if: github.repository == 'hashicorp/vagrant-builders' && !cancelled() && !failure()
     name: GitHub Release
-    needs: [info, vagrant-artifacts, post-release-branches]
+    needs: [info, vagrant-artifacts, release]
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
       id-token: write
@@ -306,38 +306,44 @@ jobs:
         env:
           RELEASE_NAME: ${{ needs.info.outputs.vagrant-tag }}
           GITHUB_TOKEN: ${{ steps.secrets.outputs.publish_token }}
-  post-release-branches:
+  unified-docs:
     if: github.repository == 'hashicorp/vagrant-builders' && !cancelled() && !failure()
-    name: GitHub Branch Updates
+    name: Create Unified Docs PR
     needs: [info, vagrant-artifacts, release]
-    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
-      id-token: write
       contents: write
+      id-token: write
+    uses: ./.github/workflows/unified-docs-release.yml
+    with:
+      release-tag: ${{ needs.info.outputs.vagrant-tag }}
+      version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+    secrets: inherit
+  next-version:
+    if: github.repository == 'hashicorp/vagrant-builders' && !cancelled() && !failure()
+    name: Calculate next version
+    runs-on: ubuntu-latest
+    needs: [vagrant-artifacts]
+    outputs:
+      version: ${{ steps.calculate-version.outputs.version }}
     steps:
-      - name: Authentication
-        id: vault-auth
-        run: vault-auth
-      - name: Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v2
-        with:
-          url: ${{ steps.vault-auth.outputs.addr }}
-          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
-          token: ${{ steps.vault-auth.outputs.token }}
-          secrets:
-            kv/data/teams/vagrant/hashibot vagrant_token;
-      - name: Code Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Vagrant Code Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          repository: hashicorp/vagrant
-          path: ./vagrant-source
-          token: ${{ steps.secrets.outputs.vagrant_token }}
-          fetch-depth: 0
-      - name: Publish Documentation Branches
-        run: ./.ci/publish-documentation-branches "${TAG_NAME}" "${VERSION}" ./vagrant-source
+      - name: calculate-version
         env:
-          VERSION: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
-          TAG_NAME: ${{ needs.info.outputs.vagrant-tag }}
+          current_version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+        run: |
+          major_minor="${current_version%.*}"
+          patch="${current_version##*.}"
+          ((patch++))
+          new_version="${major_minor}.${patch}"
+          printf "version=%s\n" >> "${GITHUB_OUTPUT}"
+  new-unified-docs-version:
+    if: github.repository == 'hashicorp/vagrant-builders' && !cancelled() && !failure()
+    name: Add New Version To Docs
+    needs: [vagrant-artifacts, next-version, unified-docs]
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/unified-docs-new-version.yml
+    with:
+      new-version: ${{ needs.next-version.outputs.version }}
+      previous-version: ${{ needs.vagrant-artifacts.outputs.vagrant-version }}
+    secrets: inherit

--- a/.github/workflows/unified-docs-new-version.yml
+++ b/.github/workflows/unified-docs-new-version.yml
@@ -1,0 +1,129 @@
+name: New Unified Docs Version
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: Vagrant documentation branch
+        type: string
+        default: vagrant/2.x
+        required: true
+      new-version:
+        description: New Vagrant version
+        type: string
+        required: true
+      previous-version:
+        description: Previous Vagrant version
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Vagrant documentation branch
+        type: string
+        default: vagrant/2.x
+        required: true
+      new-version:
+        description: New Vagrant version
+        type: string
+        required: true
+      previous-version:
+        description: Previous Vagrant version
+        type: string
+        required: true
+
+jobs:
+  create-new-version:
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    if: github.repository == 'hashicorp/vagrant-builders'
+    continue-on-error: true
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot unified_docs_token;
+      - name: Checkout local
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          path: local
+      - name: Checkout unified docs
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: hashicorp/web-unified-docs
+          token: ${{ steps.secrets.outputs.unified_docs_token }}
+          path: docs
+      - name: Create directory
+        env:
+          VERSION: ${{ inputs.new-version }}
+          PREVIOUS_VERSION: ${{ inputs.previous-version }}
+          BRANCH: ${{ inputs.branch }}
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.unified_docs_token }}
+          HASHIBOT_USERNAME: ${{ vars.HASHIBOT_USERNAME }}
+          HASHIBOT_EMAIL: ${{ vars.HASHIBOT_EMAIL }}
+        run: |
+          source local/.ci/load.sh
+          pushd docs || exit
+          export repository="hashicorp/web-unified-docs
+          hashibot_git
+
+          # Ensure versions have a v prefix
+          test "${VERSION:0:1}" != "v" && VERSION="v${VERSION}"
+          test "${PREVIOUS_VERSION:0:1}" != "v" && PREVIOUS_VERSION="v${PREVIOUS_VERSION}"
+
+          git checkout "${BRANCH}" || exit 
+          pushd content/vagrant || exit
+          
+          # If the version directory already exists, do nothing
+          if ls "${VERSION}" > /dev/null 2>&1; then
+            echo "Directory already exists, stopping"
+            exit
+          fi
+          
+          mkdir "${VERSION}" || exit
+          cp -r "./${PREVIOUS_VERSION}/." "./${VERSION}/." || exit
+          
+          git add "./${VERSION}" || exit
+          git status
+          git commit -m "Add Vagrant version ${VERSION}" || exit
+          git push origin
+  failure:
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    if: ${{ github.repository == 'hashicorp/vagrant-builders' && failure() }}
+    needs: [create-new-version]
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot webhook;
+      - name: Code Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Send Notification
+        run: |
+          . .ci/load-ci.sh || exit
+          slack -m "$(printf "Vagrant unified doc new version creation failed\n\n- <%s|%s>" "${WORKFLOW_URL}" "${WORKFLOW_NAME}")"          
+        env:
+          SLACK_WEBHOOK: ${{ steps.secrets.outputs.webhook }}
+          SLACK_CHANNEL: '#feed-vagrant'
+          SLACK_USERNAME: Vagrant Bot
+          SLACK_TITLE: Vagrant Unified Documentation
+          SLACK_STATE: error
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}          
+          
+  
+          

--- a/.github/workflows/unified-docs-release.yml
+++ b/.github/workflows/unified-docs-release.yml
@@ -1,0 +1,129 @@
+name: Generate Unified Docs PR
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Vagrant documentation branch
+        type: string
+        default: vagrant/2.x
+        required: true
+      target:
+        description: Target for PR
+        type: string
+        default: main
+        required: true
+      release-tag:
+        description: Tag for Vagrant release
+        type: string
+        required: true
+      version:
+        description: Version for Vagrant release
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      branch:
+        description: Vagrant documentation branch
+        type: string
+        default: vagrant/2.x
+        required: true
+      target:
+        description: Target for PR
+        type: string
+        default: main
+        required: true
+      release-tag:
+        description: Tag for Vagrant release
+        type: string
+        required: true
+      version:
+        description: Version for Vagrant release
+        type: string
+        required: true
+    outputs:
+      pr-url:
+        description: URL of unified docs PR
+        value: ${{ jobs.create-pr.outputs.url }}
+
+jobs:
+  create-pr:
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    if: github.repository == 'hashicorp/vagrant-builders'
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      url: ${{ steps.pr.outputs.url }}
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot unified_docs_token;
+      - name: Checkout unified docs
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: hashicorp/web-unified-docs
+          token: ${{ steps.secrets.outputs.unified_docs_token }}
+      - name: Release branch
+        env:
+          BRANCH: ${{ inputs.branch }}
+          RELEASE_BRANCH: release/vagrant-${{ inputs.release-tag }}
+        run: |
+          test "origin/${RELEASE_BRANCH}" = "$(git branch -r --list "origin/${RELEASE_BRANCH}" --format "%(refname:short)")" && exit
+          git checkout "${BRANCH}" || exit
+          git checkout -b "${RELEASE_BRANCH}"
+      - name: Create PR
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.unified_docs_token }}
+          head: release/vagrant-${{ inputs.release-tag }}
+          base: ${{ inputs.target }}
+          title: "[PUBLISH] Vagrant release ${{ inputs.release-tag }}"
+          body: |
+            Vagrant release documentation publication.
+
+            **Vagrant tag**: \`${{ inputs.release-tag }}\`
+            **Vagrant version**: \`${{ inputs.version }}\`
+        run: |
+          pr_url="$(gh pr create --base "${base}" --head "${head}" --title "${title}" --body "${body") || exit
+          printf "url=%s\n" "${pr_url}" >> "${GITHUB_OUTPUT}"
+          printf "PR: %s\n" "${pr_url}"
+  notify:
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    if: github.repository == 'hashicorp/vagrant-builders'
+    needs: [create-pr]
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/slack webhook;
+      - name: Code Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Send Notification
+        run: |
+          . .ci/load-ci.sh || exit
+          slack -m "$(printf "Vagrant unified documentation pull request generated (@vagrant)\n\n- <%s|Approve and merge>" "${PR_URL}")"
+        env:
+          SLACK_WEBHOOK: ${{ steps.secrets.outputs.webhook }}
+          SLACK_CHANNEL: '#feed-vagrant'
+          SLACK_USERNAME: Vagrant Release Process
+          SLACK_TITLE: Vagrant Unified Documentation
+          SLACK_STATE: warn
+          PR_URL: ${{ needs.create-pr.outputs.url }}
+          

--- a/.github/workflows/unified-docs-updater.yml
+++ b/.github/workflows/unified-docs-updater.yml
@@ -1,0 +1,70 @@
+name: Update Unified Documentation
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 15 5 * * *
+      
+env:
+  DOCS_BRANCH: vagrant/2.x
+    
+jobs:
+  sync-docs:
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    if: github.repository == 'hashicorp/vagrant-builders'
+    continue-on-error: true
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot unified_docs_token;
+      - name: Checkout unified docs
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: hashicorp/web-unified-docs
+          token: ${{ steps.secrets.outputs.unified_docs_token }}
+      - name: Update docs branch
+        run: |
+          git checkout "${DOCS_BRANCH}" || exit
+          git rebase main || exit
+          git push origin --force
+  failure:
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    if: ${{ github.repository == 'hashicorp/vagrant-builders' && failure() }}
+    needs: [sync-docs]
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot webhook;
+      - name: Code Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Send Notification
+        run: |
+          . .ci/load-ci.sh || exit
+          slack -m "$(printf "Vagrant unified doc sync failed\n\n- <%s|%s>" "${WORKFLOW_URL}" "${WORKFLOW_NAME}")"          
+        env:
+          SLACK_WEBHOOK: ${{ steps.secrets.outputs.webhook }}
+          SLACK_CHANNEL: '#feed-vagrant'
+          SLACK_USERNAME: Vagrant Bot
+          SLACK_TITLE: Vagrant Unified Documentation
+          SLACK_STATE: error
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}          
+          
+  


### PR DESCRIPTION
This provides updates to the release workflow to handle automatic
PR generation for documentation on the unified docs site. After
the PR is created, it will update the long lived branch with a
new directory for the next version pre-filled with the contents
of the previous version. An additional workflow is included for
scheduled updates of the long lived documentation branch to
keep it up-to-date with `main`.

All of the unified docs related workflows support being called
directly from the GitHub UI.
